### PR TITLE
Replace deprecated sonarcloud-github-action with sonarqube-scan-actio…

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,7 +13,9 @@ jobs:
 
     steps:
     - name: Git checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
@@ -25,7 +27,7 @@ jobs:
 
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
@@ -42,11 +44,7 @@ jobs:
     - name: Run test suite
       run: composer run test -- --log-junit ./reports/phpunit.xml --coverage-clover ./reports/phpunit.coverage.xml
 
-    - name: Fix code coverage paths for Sonar
-      run: sed -i 's/\/home\/runner\/work\/ngames-framework\/ngames-framework\//\/github\/workspace\//g' ./reports/*.xml || true
-
     - name: SonarCloud Scan
-      uses: sonarsource/sonarcloud-github-action@master
+      uses: SonarSource/sonarqube-scan-action@v7
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
…n v7

The sonarsource/sonarcloud-github-action was archived in Oct 2025. Migrated to the unified SonarSource/sonarqube-scan-action@v7 which supports both SonarQube Server and SonarCloud.

Also updated:
- actions/checkout v2 -> v4 with fetch-depth: 0
- actions/cache v2 -> v4
- Removed Docker path fixup (no longer needed since v5+ runs natively)
- Removed GITHUB_TOKEN env var (not required by the new action)

https://claude.ai/code/session_011YCFKzZENMKixwSHu537fp