### PR TITLE
Add attribute-based routing with middleware support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && \
     apt-get install -y libjpeg-dev libfreetype6-dev zlib1g-dev libpng-dev curl zip && \
     docker-php-ext-configure gd --with-jpeg && \
     docker-php-ext-install gd pdo pdo_mysql && \
+    pecl install apcu && docker-php-ext-enable apcu && \
     echo "access.log = /dev/null" >> /usr/local/etc/php-fpm.d/www.conf
 
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,12 @@
             "Ngames\\Framework\\" : "lib/Ngames/Framework/"
         }
     },
+    "version": "0.6.0",
     "require": {
-        "php": ">= 8.5"
+        "php": ">= 8.4"
+    },
+    "suggest": {
+        "ext-apcu": "For caching annotated route definitions"
     },
     "require-dev": {
         "phpunit/phpunit": "~12.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "148b4b845aa12b3c52a1d09162563307",
+    "content-hash": "1791c5df07b7da9fb1ef0ac876da53f8",
     "packages": [],
     "packages-dev": [
         {
@@ -4292,8 +4292,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">= 8.5"
+        "php": ">= 8.4"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/lib/Ngames/Framework/Application.php
+++ b/lib/Ngames/Framework/Application.php
@@ -183,24 +183,23 @@ class Application
             $route = $this->router->getRoute($request->getRequestUri(), $request->getMethod());
             $response = null;
 
-            if ($route == null) {
+            if ($route === null) {
                 $response = Response::createNotFoundResponse($this->isDebug() ? 'No route matched the requested URI' : null);
             } else {
                 $request->mergeGetParameters($route->getParameters());
-                $actionResult = Controller::execute($route, $request);
+                $response = Controller::execute($route, $request);
 
-                // If not a response object (string typically), constructs it (but it's a default instance)
-                if ($actionResult instanceof Response) {
-                    $response = $actionResult;
-                } elseif (is_string($actionResult)) {
+                if ($response === null) {
+                    throw new Exception('Invalid response');
+                }
+
+                // Legacy convention-based routes may return strings
+                if (is_string($response)) {
+                    $stringResult = $response;
                     $response = new Response();
                     $response->setHeader('Content-Type', 'text/html; charset=utf-8');
-                    $response->setContent($actionResult);
+                    $response->setContent($stringResult);
                 }
-            }
-
-            if ($response == null) {
-                throw new Exception('Invalid response');
             }
 
             // Send the response

--- a/lib/Ngames/Framework/Application.php
+++ b/lib/Ngames/Framework/Application.php
@@ -24,6 +24,7 @@
 
 namespace Ngames\Framework;
 
+use Ngames\Framework\Router\RouteCollector;
 use Ngames\Framework\Router\Router;
 use Ngames\Framework\Storage\IniFile;
 
@@ -147,6 +148,21 @@ class Application
     }
 
     /**
+     * Register annotated controllers from the given directories.
+     *
+     * @param array|null $directories
+     */
+    public function registerAnnotatedControllers(?array $directories = null): void
+    {
+        if ($directories === null) {
+            $directories = [ROOT_DIR . '/src/Controller'];
+        }
+
+        $collector = new RouteCollector();
+        $collector->collect($directories, $this->router);
+    }
+
+    /**
      * Whether application is in debug mode or not.
      *
      * @return boolean
@@ -164,7 +180,7 @@ class Application
         try {
             // Execute the module/controller/action
             $request = new \Ngames\Framework\Request($_GET, $_POST, $_COOKIE, $_SERVER, $_FILES, file_get_contents('php://input'));
-            $route = $this->router->getRoute($request->getRequestUri());
+            $route = $this->router->getRoute($request->getRequestUri(), $request->getMethod());
             $response = null;
 
             if ($route == null) {

--- a/lib/Ngames/Framework/Controller.php
+++ b/lib/Ngames/Framework/Controller.php
@@ -212,7 +212,8 @@ class Controller
 
         $controllerInstance = self::createController($controllerClassName, $route, $request);
 
-        $innerAction = function (Request $_request) use ($controllerInstance, $actionMethodName, $args) {
+        $innerAction = function (Request $middlewareRequest) use ($controllerInstance, $actionMethodName, $args) {
+            $controllerInstance->setRequest($middlewareRequest);
             $result = $controllerInstance->preExecute();
             if ($result === null) {
                 $result = $controllerInstance->$actionMethodName(...$args);

--- a/lib/Ngames/Framework/Controller.php
+++ b/lib/Ngames/Framework/Controller.php
@@ -225,6 +225,11 @@ class Controller
      */
     public static function execute(Route $route, Request $request)
     {
+        // Annotated route dispatch path
+        if ($route->isAnnotated()) {
+            return self::executeAnnotated($route, $request);
+        }
+
         // Get module, controller and action from the route
         $moduleName = $route->getModuleName();
         $controllerName = $route->getControllerName();
@@ -261,5 +266,127 @@ class Controller
         }
 
         return $result;
+    }
+
+    /**
+     * Execute an annotated route with parameter injection and middleware support.
+     *
+     * @param Route $route
+     * @param Request $request
+     * @return mixed
+     */
+    private static function executeAnnotated(Route $route, Request $request)
+    {
+        $controllerClassName = $route->getControllerClass();
+        $actionMethodName = $route->getActionMethod();
+
+        // Handle not found
+        if (!class_exists($controllerClassName) || !method_exists($controllerClassName, $actionMethodName)) {
+            $message = 'Not found: ' . $controllerClassName . '::' . $actionMethodName . '()';
+            \Ngames\Framework\Logger::logWarning($message);
+
+            return Response::createNotFoundResponse(\Ngames\Framework\Application::getInstance()->isDebug() ? $message : null);
+        }
+
+        // Resolve parameters via reflection
+        $args = self::resolveParameters($controllerClassName, $actionMethodName, $route);
+        if ($args instanceof Response) {
+            return $args;
+        }
+
+        // Create the controller
+        $controllerInstance = new $controllerClassName();
+        $controllerInstance->setRequest($request);
+        $controllerInstance->setRoute($route);
+
+        // Build the innermost callable (preExecute + action)
+        $innerAction = function (Request $request) use ($controllerInstance, $actionMethodName, $args) {
+            $result = $controllerInstance->preExecute();
+            if ($result === null) {
+                $result = $controllerInstance->$actionMethodName(...$args);
+            }
+
+            // Ensure we return a Response
+            if ($result instanceof Response) {
+                return $result;
+            } elseif (is_string($result)) {
+                $response = new Response();
+                $response->setHeader('Content-Type', 'text/html; charset=utf-8');
+                $response->setContent($result);
+                return $response;
+            }
+
+            return new Response();
+        };
+
+        // Build middleware chain
+        $middlewares = $route->getMiddlewares();
+        if (empty($middlewares)) {
+            return $innerAction($request);
+        }
+
+        // Build the chain from inside out
+        $next = $innerAction;
+        foreach (array_reverse($middlewares) as $middlewareClass) {
+            $currentNext = $next;
+            $next = function (Request $request) use ($middlewareClass, $currentNext) {
+                $middleware = new $middlewareClass();
+                return $middleware->handle($request, $currentNext);
+            };
+        }
+
+        return $next($request);
+    }
+
+    /**
+     * Resolve action method parameters from route parameters.
+     *
+     * @param string $controllerClassName
+     * @param string $actionMethodName
+     * @param Route $route
+     * @return array|Response
+     */
+    private static function resolveParameters($controllerClassName, $actionMethodName, Route $route)
+    {
+        $reflectionMethod = new \ReflectionMethod($controllerClassName, $actionMethodName);
+        $parameters = $reflectionMethod->getParameters();
+        $routeParams = $route->getParameters();
+        $args = [];
+
+        foreach ($parameters as $param) {
+            $name = $param->getName();
+            if (array_key_exists($name, $routeParams)) {
+                $value = $routeParams[$name];
+                $type = $param->getType();
+                if ($type instanceof \ReflectionNamedType) {
+                    $value = self::castValue($value, $type->getName());
+                }
+                $args[] = $value;
+            } elseif ($param->isDefaultValueAvailable()) {
+                $args[] = $param->getDefaultValue();
+            } else {
+                return Response::createBadRequestResponse('Missing required parameter: ' . $name);
+            }
+        }
+
+        return $args;
+    }
+
+    /**
+     * Cast a string value to the given type.
+     *
+     * @param string $value
+     * @param string $type
+     * @return mixed
+     */
+    private static function castValue($value, $type)
+    {
+        return match ($type) {
+            'int' => (int) $value,
+            'float' => (float) $value,
+            'bool' => filter_var($value, FILTER_VALIDATE_BOOLEAN),
+            'string' => (string) $value,
+            default => $value,
+        };
     }
 }

--- a/lib/Ngames/Framework/Controller.php
+++ b/lib/Ngames/Framework/Controller.php
@@ -212,7 +212,7 @@ class Controller
 
         $controllerInstance = self::createController($controllerClassName, $route, $request);
 
-        $innerAction = function (Request $request) use ($controllerInstance, $actionMethodName, $args) {
+        $innerAction = function (Request $_request) use ($controllerInstance, $actionMethodName, $args) {
             $result = $controllerInstance->preExecute();
             if ($result === null) {
                 $result = $controllerInstance->$actionMethodName(...$args);

--- a/lib/Ngames/Framework/Controller.php
+++ b/lib/Ngames/Framework/Controller.php
@@ -102,67 +102,31 @@ class Controller
 
     // Status helper methods
 
-    /**
-     * Return a successful response
-     *
-     * @param string|null $content
-     * @return Response
-     */
     protected function ok($content = null)
     {
         return Response::createOkResponse($content);
     }
 
-    /**
-     * Return a redirect response
-     *
-     * @param string $url
-     * @return Response
-     */
     protected function redirect($url)
     {
         return Response::createRedirectResponse($url);
     }
 
-    /**
-     * Return a not found response
-     *
-     * @param string|null $message
-     * @return Response
-     */
     protected function notFound($message = null)
     {
         return Response::createNotFoundResponse($message);
     }
 
-    /**
-     * Return a bad request response
-     *
-     * @param string|null $message
-     * @return Response
-     */
     protected function badRequest($message = null)
     {
         return Response::createBadRequestResponse($message);
     }
 
-    /**
-     * Return an internal error response
-     *
-     * @param string|null $message
-     * @return Response
-     */
     protected function internalError($message = null)
     {
         return Response::createInternalErrorResponse($message);
     }
 
-    /**
-     * Return an unauthorized response
-     *
-     * @param string|null $message
-     * @return Response
-     */
     protected function unauthorized($message = null)
     {
         return Response::createUnauthorizedResponse($message);
@@ -172,6 +136,8 @@ class Controller
      * Forward the request to another action.
      * Contrary to redirect, no HTTP response is sent to the user between the two actions.
      *
+     * @deprecated Use attribute-based routing instead of convention-based forwarding.
+     *
      * @param string $actionName
      * @param string|null $controllerName
      * @param string|null $moduleName
@@ -179,24 +145,18 @@ class Controller
      */
     protected function forward($actionName, $controllerName = null, $moduleName = null)
     {
-        // If module or controller not provided, use current route to determine current ones and use them
-        if ($moduleName === null || $controllerName === null) {
-            if ($moduleName === null) {
-                $moduleName = $this->route->getModuleName();
-            }
-            if ($controllerName === null) {
-                $controllerName = $this->route->getControllerName();
-            }
+        if ($moduleName === null) {
+            $moduleName = $this->route->getModuleName();
+        }
+        if ($controllerName === null) {
+            $controllerName = $this->route->getControllerName();
         }
 
-        // Build a new request
         $requestClone = clone $this->request;
         $requestClone->setRequestUri('/' . $moduleName . '/' . $controllerName . '/' . $actionName);
 
-        // Build a new route
-        $forwardRoute = new Route($moduleName, $controllerName, $actionName);
+        $forwardRoute = Route::createLegacy($moduleName, $controllerName, $actionName);
 
-        // Execute again for the forward
         return self::execute($forwardRoute, $requestClone);
     }
 
@@ -206,7 +166,7 @@ class Controller
      * @param mixed $json
      * @param int $options
      *
-     * @return \Ngames\Framework\Response
+     * @return Response
      */
     protected function json($json, $options = JSON_PRETTY_PRINT)
     {
@@ -218,105 +178,47 @@ class Controller
     }
 
     /**
-     * Execute the provided request.
+     * Execute a route.
      *
+     * @param Route $route
      * @param Request $request
      * @return mixed
      */
     public static function execute(Route $route, Request $request)
     {
-        // Annotated route dispatch path
         if ($route->isAnnotated()) {
             return self::executeAnnotated($route, $request);
         }
 
-        // Get module, controller and action from the route
-        $moduleName = $route->getModuleName();
-        $controllerName = $route->getControllerName();
-        $actionName = $route->getActionName();
-
-        // Build controller class name
-        $controllerClassName = self::CONTROLLER_NAMESPACE . '\\';
-        $controllerClassName .= ucfirst(Inflector::camelize(str_replace('-', '_', $moduleName))) . '\\';
-        $controllerClassName .= ucfirst(Inflector::camelize(str_replace('-', '_', $controllerName)));
-        $controllerClassName .= self::CONTROLLER_SUFFIX;
-
-        // Build action method name
-        $actionMethodName = Inflector::camelize(str_replace('-', '_', $actionName)) . self::ACTION_SUFFIX;
-
-        // Handle not found (test if class is loadable, exists and method exists)
-        if (!class_exists($controllerClassName) || !method_exists($controllerClassName, $actionMethodName)) {
-            $message = 'Not found: ' . $controllerClassName . '::' . $actionMethodName . '()';
-            \Ngames\Framework\Logger::logWarning($message);
-
-            return Response::createNotFoundResponse(\Ngames\Framework\Application::getInstance()->isDebug() ? $message : null);
-        }
-
-        // Create the controller
-        $controllerInstance = new $controllerClassName();
-        $controllerInstance->setRequest($request);
-        $controllerInstance->setRoute($route);
-
-        // Execute pre-execute
-        $result = $controllerInstance->preExecute();
-
-        // If pre-execute did not return an output, execute the action
-        if ($result === null) {
-            $result = $controllerInstance->$actionMethodName();
-        }
-
-        return $result;
+        return self::executeLegacy($route, $request);
     }
 
     /**
      * Execute an annotated route with parameter injection and middleware support.
-     *
-     * @param Route $route
-     * @param Request $request
-     * @return mixed
      */
     private static function executeAnnotated(Route $route, Request $request)
     {
         $controllerClassName = $route->getControllerClass();
         $actionMethodName = $route->getActionMethod();
 
-        // Handle not found
         if (!class_exists($controllerClassName) || !method_exists($controllerClassName, $actionMethodName)) {
-            $message = 'Not found: ' . $controllerClassName . '::' . $actionMethodName . '()';
-            \Ngames\Framework\Logger::logWarning($message);
-
-            return Response::createNotFoundResponse(\Ngames\Framework\Application::getInstance()->isDebug() ? $message : null);
+            return self::notFoundResponse($controllerClassName, $actionMethodName);
         }
 
-        // Resolve parameters via reflection
         $args = self::resolveParameters($controllerClassName, $actionMethodName, $route);
         if ($args instanceof Response) {
             return $args;
         }
 
-        // Create the controller
-        $controllerInstance = new $controllerClassName();
-        $controllerInstance->setRequest($request);
-        $controllerInstance->setRoute($route);
+        $controllerInstance = self::createController($controllerClassName, $route, $request);
 
-        // Build the innermost callable (preExecute + action)
         $innerAction = function (Request $request) use ($controllerInstance, $actionMethodName, $args) {
             $result = $controllerInstance->preExecute();
             if ($result === null) {
                 $result = $controllerInstance->$actionMethodName(...$args);
             }
 
-            // Ensure we return a Response
-            if ($result instanceof Response) {
-                return $result;
-            } elseif (is_string($result)) {
-                $response = new Response();
-                $response->setHeader('Content-Type', 'text/html; charset=utf-8');
-                $response->setContent($result);
-                return $response;
-            }
-
-            return new Response();
+            return self::toResponse($result);
         };
 
         // Build middleware chain (wrapping from inside out)
@@ -333,21 +235,92 @@ class Controller
     }
 
     /**
+     * Execute a convention-based route (legacy).
+     *
+     * @deprecated Use attribute-based routing instead.
+     */
+    private static function executeLegacy(Route $route, Request $request)
+    {
+        $moduleName = $route->getModuleName();
+        $controllerName = $route->getControllerName();
+        $actionName = $route->getActionName();
+
+        $controllerClassName = self::CONTROLLER_NAMESPACE . '\\';
+        $controllerClassName .= ucfirst(Inflector::camelize(str_replace('-', '_', $moduleName))) . '\\';
+        $controllerClassName .= ucfirst(Inflector::camelize(str_replace('-', '_', $controllerName)));
+        $controllerClassName .= self::CONTROLLER_SUFFIX;
+
+        $actionMethodName = Inflector::camelize(str_replace('-', '_', $actionName)) . self::ACTION_SUFFIX;
+
+        if (!class_exists($controllerClassName) || !method_exists($controllerClassName, $actionMethodName)) {
+            return self::notFoundResponse($controllerClassName, $actionMethodName);
+        }
+
+        $controllerInstance = self::createController($controllerClassName, $route, $request);
+
+        $result = $controllerInstance->preExecute();
+        if ($result === null) {
+            $result = $controllerInstance->$actionMethodName();
+        }
+
+        return $result;
+    }
+
+    /**
+     * Instantiate a controller and bind the route and request to it.
+     */
+    private static function createController(string $className, Route $route, Request $request): self
+    {
+        $controller = new $className();
+        $controller->setRequest($request);
+        $controller->setRoute($route);
+
+        return $controller;
+    }
+
+    /**
+     * Create a not-found response with optional debug info.
+     */
+    private static function notFoundResponse(string $className, string $methodName): Response
+    {
+        $message = 'Not found: ' . $className . '::' . $methodName . '()';
+        Logger::logWarning($message);
+
+        return Response::createNotFoundResponse(Application::getInstance()->isDebug() ? $message : null);
+    }
+
+    /**
+     * Convert an action result to a Response.
+     */
+    private static function toResponse($result): Response
+    {
+        if ($result instanceof Response) {
+            return $result;
+        }
+
+        if (is_string($result)) {
+            $response = new Response();
+            $response->setHeader('Content-Type', 'text/html; charset=utf-8');
+            $response->setContent($result);
+
+            return $response;
+        }
+
+        return new Response();
+    }
+
+    /**
      * Resolve action method parameters from route parameters.
      *
-     * @param string $controllerClassName
-     * @param string $actionMethodName
-     * @param Route $route
      * @return array|Response
      */
-    private static function resolveParameters($controllerClassName, $actionMethodName, Route $route)
+    private static function resolveParameters(string $className, string $methodName, Route $route)
     {
-        $reflectionMethod = new \ReflectionMethod($controllerClassName, $actionMethodName);
-        $parameters = $reflectionMethod->getParameters();
+        $reflectionMethod = new \ReflectionMethod($className, $methodName);
         $routeParams = $route->getParameters();
         $args = [];
 
-        foreach ($parameters as $param) {
+        foreach ($reflectionMethod->getParameters() as $param) {
             $name = $param->getName();
             if (array_key_exists($name, $routeParams)) {
                 $value = $routeParams[$name];
@@ -369,17 +342,14 @@ class Controller
     /**
      * Cast a string value to the given type.
      *
-     * @param string $value
-     * @param string $type
      * @return mixed
      */
-    private static function castValue($value, $type)
+    private static function castValue(string $value, string $type)
     {
         return match ($type) {
             'int' => (int) $value,
             'float' => (float) $value,
             'bool' => filter_var($value, FILTER_VALIDATE_BOOLEAN),
-            'string' => (string) $value,
             default => $value,
         };
     }

--- a/lib/Ngames/Framework/Controller.php
+++ b/lib/Ngames/Framework/Controller.php
@@ -319,15 +319,9 @@ class Controller
             return new Response();
         };
 
-        // Build middleware chain
-        $middlewares = $route->getMiddlewares();
-        if (empty($middlewares)) {
-            return $innerAction($request);
-        }
-
-        // Build the chain from inside out
+        // Build middleware chain (wrapping from inside out)
         $next = $innerAction;
-        foreach (array_reverse($middlewares) as $middlewareClass) {
+        foreach (array_reverse($route->getMiddlewares()) as $middlewareClass) {
             $currentNext = $next;
             $next = function (Request $request) use ($middlewareClass, $currentNext) {
                 $middleware = new $middlewareClass();

--- a/lib/Ngames/Framework/Router/Attribute/Delete.php
+++ b/lib/Ngames/Framework/Router/Attribute/Delete.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Ngames\Framework\Router\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class Delete
+{
+    public function __construct(public string $path = '')
+    {
+    }
+}

--- a/lib/Ngames/Framework/Router/Attribute/Get.php
+++ b/lib/Ngames/Framework/Router/Attribute/Get.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Ngames\Framework\Router\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class Get
+{
+    public function __construct(public string $path = '')
+    {
+    }
+}

--- a/lib/Ngames/Framework/Router/Attribute/Middleware.php
+++ b/lib/Ngames/Framework/Router/Attribute/Middleware.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Ngames\Framework\Router\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+class Middleware
+{
+    public function __construct(public string $class)
+    {
+    }
+}

--- a/lib/Ngames/Framework/Router/Attribute/Patch.php
+++ b/lib/Ngames/Framework/Router/Attribute/Patch.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Ngames\Framework\Router\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class Patch
+{
+    public function __construct(public string $path = '')
+    {
+    }
+}

--- a/lib/Ngames/Framework/Router/Attribute/Post.php
+++ b/lib/Ngames/Framework/Router/Attribute/Post.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Ngames\Framework\Router\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class Post
+{
+    public function __construct(public string $path = '')
+    {
+    }
+}

--- a/lib/Ngames/Framework/Router/Attribute/Put.php
+++ b/lib/Ngames/Framework/Router/Attribute/Put.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Ngames\Framework\Router\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class Put
+{
+    public function __construct(public string $path = '')
+    {
+    }
+}

--- a/lib/Ngames/Framework/Router/Attribute/Route.php
+++ b/lib/Ngames/Framework/Router/Attribute/Route.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Ngames\Framework\Router\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class Route
+{
+    public function __construct(public string $path = '')
+    {
+    }
+}

--- a/lib/Ngames/Framework/Router/Matcher.php
+++ b/lib/Ngames/Framework/Router/Matcher.php
@@ -25,8 +25,7 @@
 namespace Ngames\Framework\Router;
 
 /**
- * Matcher class used to identify matching route for a given requested URI
- *
+ * Matcher class used to identify matching route for a given requested URI.
  */
 class Matcher
 {
@@ -36,83 +35,87 @@ class Matcher
 
     public const ACTION_KEY = ':action';
 
-    private $pattern;
+    private string $pattern;
 
-    private $moduleName;
+    private ?string $name;
 
-    private $controllerName;
+    private ?string $method;
 
-    private $actionName;
+    private ?string $controllerClass;
 
-    private $name;
+    private ?string $actionMethod;
 
-    private $method;
+    private array $middlewares;
 
-    private $controllerClass;
+    // Legacy convention-based fields
+    private ?string $moduleName = null;
 
-    private $actionMethod;
+    private ?string $controllerName = null;
 
-    private $middlewares;
+    private ?string $actionName = null;
 
     /**
-     * Create a new matcher that will be used to test the route eligility.
+     * Create a matcher for an attribute-based route.
      *
-     * The pattern may define the URI part where module, controller or action are read. If not, the corresponding element must have a value defined.
-     *
-     * Samples pattern are:
-     * /home + module=default, controller=index, action=index
-     * /:controller/:action + module=default
-     * Etc.
-     *
-     * @param string $pattern
-     * @param string|null $moduleName
-     * @param string|null $controllerName
-     * @param string|null $actionName
-     * @param string|null $name
-     * @param string|null $method
+     * @param string $pattern The URI pattern (e.g. /api/users/:id)
+     * @param string $httpMethod The HTTP method (GET, POST, etc.)
+     * @param string $controllerClass Fully qualified controller class name
+     * @param string $actionMethod Method name on the controller
+     * @param array $middlewares Middleware class names
+     * @param string|null $name Optional route name for URL generation
      */
     public function __construct(
-        $pattern,
-        $moduleName = null,
-        $controllerName = null,
-        $actionName = null,
-        $name = null,
-        $method = null
-    ) {
-        $this->pattern = $pattern;
-        $this->moduleName = $moduleName;
-        $this->controllerName = $controllerName;
-        $this->actionName = $actionName;
-        $this->name = $name;
-        $this->method = $method !== null ? strtoupper($method) : null;
-        $this->middlewares = [];
-        $this->check();
-    }
-
-    /**
-     * Create a matcher for an annotated route (attribute-based routing).
-     */
-    public static function forAnnotatedRoute(
         string $pattern,
         string $httpMethod,
         string $controllerClass,
         string $actionMethod,
-        array $middlewares = []
+        array $middlewares = [],
+        ?string $name = null
+    ) {
+        $this->pattern = $pattern;
+        $this->method = strtoupper($httpMethod);
+        $this->controllerClass = $controllerClass;
+        $this->actionMethod = $actionMethod;
+        $this->middlewares = $middlewares;
+        $this->name = $name;
+    }
+
+    /**
+     * Create a matcher for convention-based routing (module/controller/action).
+     *
+     * @deprecated Use attribute-based routing instead. Convention-based routing will be removed in a future version.
+     */
+    public static function forConventionRoute(
+        string $pattern,
+        ?string $moduleName = null,
+        ?string $controllerName = null,
+        ?string $actionName = null,
+        ?string $name = null,
+        ?string $method = null
     ): self {
-        $matcher = new \ReflectionClass(self::class);
-        $instance = $matcher->newInstanceWithoutConstructor();
-        $instance->pattern = $pattern;
-        $instance->method = strtoupper($httpMethod);
-        $instance->controllerClass = $controllerClass;
-        $instance->actionMethod = $actionMethod;
-        $instance->middlewares = $middlewares;
-        return $instance;
+        @trigger_error(
+            'Convention-based routing (module/controller/action) is deprecated. Use attribute-based routing instead.',
+            E_USER_DEPRECATED
+        );
+
+        $matcher = new self($pattern, $method ?? 'ANY', '', '');
+        $matcher->moduleName = $moduleName;
+        $matcher->controllerName = $controllerName;
+        $matcher->actionName = $actionName;
+        $matcher->name = $name;
+        $matcher->method = $method !== null ? strtoupper($method) : null;
+        $matcher->controllerClass = null;
+        $matcher->actionMethod = null;
+        $matcher->middlewares = [];
+        $matcher->checkConventionRoute();
+
+        return $matcher;
     }
 
     /**
      * @return string|null
      */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -120,7 +123,7 @@ class Matcher
     /**
      * @return string
      */
-    public function getPattern()
+    public function getPattern(): string
     {
         return $this->pattern;
     }
@@ -128,23 +131,20 @@ class Matcher
     /**
      * @return string|null
      */
-    public function getMethod()
+    public function getMethod(): ?string
     {
         return $this->method;
     }
 
     /**
      * Tries to match the input URI.
-     * Output is null if no match, a route otherwise.
      *
      * @param string $uri
      * @param string|null $method
-     *
      * @return Route|null
      */
-    public function match($uri, $method = null)
+    public function match($uri, $method = null): ?Route
     {
-        // Check HTTP method constraint
         if ($this->method !== null && $method !== null && strtoupper($method) !== $this->method) {
             return null;
         }
@@ -155,24 +155,28 @@ class Matcher
             return null;
         }
 
-        return new Route(
+        if ($this->controllerClass !== null) {
+            return Route::create(
+                $this->controllerClass,
+                $this->actionMethod,
+                $result['parameters'],
+                $this->middlewares
+            );
+        }
+
+        // Legacy convention-based route
+        return Route::createLegacy(
             $result['moduleName'],
             $result['controllerName'],
             $result['actionName'],
-            $result['parameters'],
-            $this->controllerClass,
-            $this->actionMethod,
-            $this->middlewares ?? []
+            $result['parameters']
         );
     }
 
     /**
      * Match the URI against the pattern and extract route components.
-     *
-     * @param string $uri
-     * @return array|null
      */
-    private function matchPattern($uri)
+    private function matchPattern($uri): ?array
     {
         $preparedPattern = $this->prepareForMatching($this->pattern);
         $preparedUri = $this->prepareForMatching($uri);
@@ -216,11 +220,11 @@ class Matcher
     }
 
     /**
-     * Checks that the configuration of the matcher is valid and throws an exception otherwise.
+     * Validate convention-based matcher configuration.
      *
      * @throws InvalidMatcherException
      */
-    private function check()
+    private function checkConventionRoute(): void
     {
         if (!($this->moduleName !== null xor strpos($this->pattern, self::MODULE_KEY) !== false)) {
             throw new InvalidMatcherException('Missing module key or module value, or provided both');
@@ -235,13 +239,11 @@ class Matcher
 
     /**
      * Return an array containing the URI/pattern parts.
-     *
-     * @param string $uri
      */
-    private function prepareForMatching($uri)
+    private function prepareForMatching($uri): array
     {
         return array_values(array_filter(explode('/', $uri ?? ''), function ($uriPart) {
-            return !empty($uriPart);
+            return $uriPart !== '';
         }));
     }
 }

--- a/lib/Ngames/Framework/Router/Matcher.php
+++ b/lib/Ngames/Framework/Router/Matcher.php
@@ -46,6 +46,14 @@ class Matcher
 
     private $name;
 
+    private $method;
+
+    private $controllerClass;
+
+    private $actionMethod;
+
+    private $middlewares;
+
     /**
      * Create a new matcher that will be used to test the route eligility.
      *
@@ -61,16 +69,36 @@ class Matcher
      * @param string|null $controllerName
      * @param string|null $actionName
      * @param string|null $name
+     * @param string|null $method
+     * @param string|null $controllerClass
+     * @param string|null $actionMethod
+     * @param array $middlewares
      */
-    public function __construct($pattern, $moduleName = null, $controllerName = null, $actionName = null, $name = null)
-    {
+    public function __construct(
+        $pattern,
+        $moduleName = null,
+        $controllerName = null,
+        $actionName = null,
+        $name = null,
+        $method = null,
+        $controllerClass = null,
+        $actionMethod = null,
+        array $middlewares = []
+    ) {
         $this->pattern = $pattern;
         $this->moduleName = $moduleName;
         $this->controllerName = $controllerName;
         $this->actionName = $actionName;
         $this->name = $name;
+        $this->method = $method !== null ? strtoupper($method) : null;
+        $this->controllerClass = $controllerClass;
+        $this->actionMethod = $actionMethod;
+        $this->middlewares = $middlewares;
 
-        $this->check();
+        // Skip validation for annotated routes (they don't use module/controller/action)
+        if ($controllerClass === null) {
+            $this->check();
+        }
     }
 
     /**
@@ -90,15 +118,29 @@ class Matcher
     }
 
     /**
+     * @return string|null
+     */
+    public function getMethod()
+    {
+        return $this->method;
+    }
+
+    /**
      * Tries to match the input URI.
      * Output is null if no match, a route otherwise.
      *
      * @param string $uri
+     * @param string|null $method
      *
      * @return Route|null
      */
-    public function match($uri)
+    public function match($uri, $method = null)
     {
+        // Check HTTP method constraint
+        if ($this->method !== null && $method !== null && strtoupper($method) !== $this->method) {
+            return null;
+        }
+
         $preparedPattern = $this->prepareForMatching($this->pattern);
         $uri = $this->prepareForMatching($uri);
         $currentModuleName = $this->moduleName;
@@ -132,7 +174,24 @@ class Matcher
             }
         }
 
-        return $match ? new Route($currentModuleName, $currentControllerName, $currentActionName, $parameters) : null;
+        if (!$match) {
+            return null;
+        }
+
+        // For annotated routes, create a Route with controller class metadata
+        if ($this->controllerClass !== null) {
+            return new Route(
+                $currentModuleName,
+                $currentControllerName,
+                $currentActionName,
+                $parameters,
+                $this->controllerClass,
+                $this->actionMethod,
+                $this->middlewares
+            );
+        }
+
+        return new Route($currentModuleName, $currentControllerName, $currentActionName, $parameters);
     }
 
     /**

--- a/lib/Ngames/Framework/Router/Matcher.php
+++ b/lib/Ngames/Framework/Router/Matcher.php
@@ -70,9 +70,6 @@ class Matcher
      * @param string|null $actionName
      * @param string|null $name
      * @param string|null $method
-     * @param string|null $controllerClass
-     * @param string|null $actionMethod
-     * @param array $middlewares
      */
     public function __construct(
         $pattern,
@@ -80,10 +77,7 @@ class Matcher
         $controllerName = null,
         $actionName = null,
         $name = null,
-        $method = null,
-        $controllerClass = null,
-        $actionMethod = null,
-        array $middlewares = []
+        $method = null
     ) {
         $this->pattern = $pattern;
         $this->moduleName = $moduleName;
@@ -91,14 +85,28 @@ class Matcher
         $this->actionName = $actionName;
         $this->name = $name;
         $this->method = $method !== null ? strtoupper($method) : null;
-        $this->controllerClass = $controllerClass;
-        $this->actionMethod = $actionMethod;
-        $this->middlewares = $middlewares;
+        $this->middlewares = [];
+        $this->check();
+    }
 
-        // Skip validation for annotated routes (they don't use module/controller/action)
-        if ($controllerClass === null) {
-            $this->check();
-        }
+    /**
+     * Create a matcher for an annotated route (attribute-based routing).
+     */
+    public static function forAnnotatedRoute(
+        string $pattern,
+        string $httpMethod,
+        string $controllerClass,
+        string $actionMethod,
+        array $middlewares = []
+    ): self {
+        $matcher = new \ReflectionClass(self::class);
+        $instance = $matcher->newInstanceWithoutConstructor();
+        $instance->pattern = $pattern;
+        $instance->method = strtoupper($httpMethod);
+        $instance->controllerClass = $controllerClass;
+        $instance->actionMethod = $actionMethod;
+        $instance->middlewares = $middlewares;
+        return $instance;
     }
 
     /**
@@ -141,57 +149,70 @@ class Matcher
             return null;
         }
 
-        $preparedPattern = $this->prepareForMatching($this->pattern);
-        $uri = $this->prepareForMatching($uri);
-        $currentModuleName = $this->moduleName;
-        $currentControllerName = $this->controllerName;
-        $currentActionName = $this->actionName;
-        $parameters = [];
-        $countPattern = count($preparedPattern);
-        $match = true;
+        $result = $this->matchPattern($uri);
 
-        if ($countPattern !== count($uri)) {
-            $match = false;
-        } else {
-            for ($i = 0; $i < $countPattern; $i++) {
-                $currentPatternPart = $preparedPattern[$i];
-                $currentUriPart = $uri[$i];
-
-                if ($currentPatternPart !== $currentUriPart) {
-                    if ($currentPatternPart === self::MODULE_KEY) {
-                        $currentModuleName = $currentUriPart;
-                    } elseif ($currentPatternPart === self::CONTROLLER_KEY) {
-                        $currentControllerName = $currentUriPart;
-                    } elseif ($currentPatternPart === self::ACTION_KEY) {
-                        $currentActionName = $currentUriPart;
-                    } elseif (str_starts_with($currentPatternPart, ':')) {
-                        $parameters[substr($currentPatternPart, 1)] = $currentUriPart;
-                    } else {
-                        $match = false;
-                        break;
-                    }
-                }
-            }
-        }
-
-        if (!$match) {
+        if ($result === null) {
             return null;
         }
 
-        // For annotated routes, create a Route with controller class metadata
-        if ($this->controllerClass !== null) {
-            return new Route(
-                $currentModuleName,
-                $currentControllerName,
-                $currentActionName,
-                $parameters,
-                $this->controllerClass,
-                $this->actionMethod,
-                $this->middlewares
-            );
+        return new Route(
+            $result['moduleName'],
+            $result['controllerName'],
+            $result['actionName'],
+            $result['parameters'],
+            $this->controllerClass,
+            $this->actionMethod,
+            $this->middlewares ?? []
+        );
+    }
+
+    /**
+     * Match the URI against the pattern and extract route components.
+     *
+     * @param string $uri
+     * @return array|null
+     */
+    private function matchPattern($uri)
+    {
+        $preparedPattern = $this->prepareForMatching($this->pattern);
+        $preparedUri = $this->prepareForMatching($uri);
+
+        if (count($preparedPattern) !== count($preparedUri)) {
+            return null;
         }
 
-        return new Route($currentModuleName, $currentControllerName, $currentActionName, $parameters);
+        $moduleName = $this->moduleName;
+        $controllerName = $this->controllerName;
+        $actionName = $this->actionName;
+        $parameters = [];
+
+        for ($i = 0; $i < count($preparedPattern); $i++) {
+            $patternPart = $preparedPattern[$i];
+            $uriPart = $preparedUri[$i];
+
+            if ($patternPart === $uriPart) {
+                continue;
+            }
+
+            if ($patternPart === self::MODULE_KEY) {
+                $moduleName = $uriPart;
+            } elseif ($patternPart === self::CONTROLLER_KEY) {
+                $controllerName = $uriPart;
+            } elseif ($patternPart === self::ACTION_KEY) {
+                $actionName = $uriPart;
+            } elseif (str_starts_with($patternPart, ':')) {
+                $parameters[substr($patternPart, 1)] = $uriPart;
+            } else {
+                return null;
+            }
+        }
+
+        return [
+            'moduleName' => $moduleName,
+            'controllerName' => $controllerName,
+            'actionName' => $actionName,
+            'parameters' => $parameters,
+        ];
     }
 
     /**

--- a/lib/Ngames/Framework/Router/Matcher.php
+++ b/lib/Ngames/Framework/Router/Matcher.php
@@ -98,18 +98,29 @@ class Matcher
             E_USER_DEPRECATED
         );
 
-        $matcher = new self($pattern, $method ?? 'ANY', '', '');
-        $matcher->moduleName = $moduleName;
-        $matcher->controllerName = $controllerName;
-        $matcher->actionName = $actionName;
-        $matcher->name = $name;
-        $matcher->method = $method !== null ? strtoupper($method) : null;
-        $matcher->controllerClass = null;
-        $matcher->actionMethod = null;
-        $matcher->middlewares = [];
-        $matcher->checkConventionRoute();
+        $matcher = new self($pattern, $method ?? 'ANY', '', '', [], $name);
+        $matcher->initLegacy($moduleName, $controllerName, $actionName, $method);
 
         return $matcher;
+    }
+
+    /**
+     * Initialize legacy convention-based fields and validate.
+     */
+    private function initLegacy(
+        ?string $moduleName,
+        ?string $controllerName,
+        ?string $actionName,
+        ?string $method
+    ): void {
+        $this->moduleName = $moduleName;
+        $this->controllerName = $controllerName;
+        $this->actionName = $actionName;
+        $this->method = $method !== null ? strtoupper($method) : null;
+        $this->controllerClass = null;
+        $this->actionMethod = null;
+        $this->middlewares = [];
+        $this->checkConventionRoute();
     }
 
     /**

--- a/lib/Ngames/Framework/Router/Matcher.php
+++ b/lib/Ngames/Framework/Router/Matcher.php
@@ -166,22 +166,9 @@ class Matcher
             return null;
         }
 
-        if ($this->controllerClass !== null) {
-            return Route::create(
-                $this->controllerClass,
-                $this->actionMethod,
-                $result['parameters'],
-                $this->middlewares
-            );
-        }
-
-        // Legacy convention-based route
-        return Route::createLegacy(
-            $result['moduleName'],
-            $result['controllerName'],
-            $result['actionName'],
-            $result['parameters']
-        );
+        return $this->controllerClass !== null
+            ? Route::create($this->controllerClass, $this->actionMethod, $result['parameters'], $this->middlewares)
+            : Route::createLegacy($result['moduleName'], $result['controllerName'], $result['actionName'], $result['parameters']);
     }
 
     /**

--- a/lib/Ngames/Framework/Router/MiddlewareInterface.php
+++ b/lib/Ngames/Framework/Router/MiddlewareInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Ngames\Framework\Router;
+
+use Ngames\Framework\Request;
+use Ngames\Framework\Response;
+
+interface MiddlewareInterface
+{
+    public function handle(Request $request, callable $next): Response;
+}

--- a/lib/Ngames/Framework/Router/Route.php
+++ b/lib/Ngames/Framework/Router/Route.php
@@ -55,18 +55,46 @@ class Route
     private $parameters = [];
 
     /**
+     * @var string|null
+     */
+    private $controllerClass;
+
+    /**
+     * @var string|null
+     */
+    private $actionMethod;
+
+    /**
+     * @var array
+     */
+    private $middlewares = [];
+
+    /**
      *
      * @param string $moduleName
      * @param string $controllerName
      * @param string $actionName
      * @param array $parameters
+     * @param string|null $controllerClass
+     * @param string|null $actionMethod
+     * @param array $middlewares
      */
-    public function __construct($moduleName, $controllerName, $actionName, array $parameters = [])
-    {
+    public function __construct(
+        $moduleName,
+        $controllerName,
+        $actionName,
+        array $parameters = [],
+        $controllerClass = null,
+        $actionMethod = null,
+        array $middlewares = []
+    ) {
         $this->moduleName = $moduleName;
         $this->controllerName = $controllerName;
         $this->actionName = $actionName;
         $this->parameters = $parameters;
+        $this->controllerClass = $controllerClass;
+        $this->actionMethod = $actionMethod;
+        $this->middlewares = $middlewares;
     }
 
     /**
@@ -112,5 +140,37 @@ class Route
     public function getParameter($name, $default = null)
     {
         return array_key_exists($name, $this->parameters) ? $this->parameters[$name] : $default;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getControllerClass()
+    {
+        return $this->controllerClass;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getActionMethod()
+    {
+        return $this->actionMethod;
+    }
+
+    /**
+     * @return array
+     */
+    public function getMiddlewares()
+    {
+        return $this->middlewares;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isAnnotated()
+    {
+        return $this->controllerClass !== null;
     }
 }

--- a/lib/Ngames/Framework/Router/Route.php
+++ b/lib/Ngames/Framework/Router/Route.php
@@ -26,151 +26,125 @@ namespace Ngames\Framework\Router;
 
 /**
  * A route returned by the router.
- * It is a simple wrapper over the found module/controller/action.
- *
  */
 class Route
 {
-    /**
-     *
-     * @var string
-     */
-    protected $moduleName;
+    private ?string $controllerClass;
+
+    private ?string $actionMethod;
+
+    private array $parameters;
+
+    private array $middlewares;
+
+    // Legacy convention-based fields
+    private ?string $moduleName;
+
+    private ?string $controllerName;
+
+    private ?string $actionName;
+
+    private function __construct()
+    {
+    }
 
     /**
-     *
-     * @var string
+     * Create an annotated route.
      */
-    protected $controllerName;
-
-    /**
-     *
-     * @var string
-     */
-    protected $actionName;
-
-    /**
-     * @var array
-     */
-    private $parameters = [];
-
-    /**
-     * @var string|null
-     */
-    private $controllerClass;
-
-    /**
-     * @var string|null
-     */
-    private $actionMethod;
-
-    /**
-     * @var array
-     */
-    private $middlewares = [];
-
-    /**
-     *
-     * @param string $moduleName
-     * @param string $controllerName
-     * @param string $actionName
-     * @param array $parameters
-     * @param string|null $controllerClass
-     * @param string|null $actionMethod
-     * @param array $middlewares
-     */
-    public function __construct(
-        $moduleName,
-        $controllerName,
-        $actionName,
+    public static function create(
+        string $controllerClass,
+        string $actionMethod,
         array $parameters = [],
-        $controllerClass = null,
-        $actionMethod = null,
         array $middlewares = []
-    ) {
-        $this->moduleName = $moduleName;
-        $this->controllerName = $controllerName;
-        $this->actionName = $actionName;
-        $this->parameters = $parameters;
-        $this->controllerClass = $controllerClass;
-        $this->actionMethod = $actionMethod;
-        $this->middlewares = $middlewares;
+    ): self {
+        $route = new self();
+        $route->controllerClass = $controllerClass;
+        $route->actionMethod = $actionMethod;
+        $route->parameters = $parameters;
+        $route->middlewares = $middlewares;
+        $route->moduleName = null;
+        $route->controllerName = null;
+        $route->actionName = null;
+        return $route;
     }
 
     /**
+     * Create a convention-based route (legacy).
      *
-     * @return string
+     * @deprecated Use attribute-based routing instead.
      */
-    public function getModuleName()
-    {
-        return $this->moduleName;
+    public static function createLegacy(
+        string $moduleName,
+        string $controllerName,
+        string $actionName,
+        array $parameters = []
+    ): self {
+        $route = new self();
+        $route->moduleName = $moduleName;
+        $route->controllerName = $controllerName;
+        $route->actionName = $actionName;
+        $route->parameters = $parameters;
+        $route->controllerClass = null;
+        $route->actionMethod = null;
+        $route->middlewares = [];
+        return $route;
     }
 
-    /**
-     *
-     * @return string
-     */
-    public function getControllerName()
+    public function isAnnotated(): bool
     {
-        return $this->controllerName;
+        return $this->controllerClass !== null;
     }
 
-    /**
-     *
-     * @return string
-     */
-    public function getActionName()
+    public function getControllerClass(): ?string
     {
-        return $this->actionName;
+        return $this->controllerClass;
     }
 
-    /**
-     * @return array
-     */
-    public function getParameters()
+    public function getActionMethod(): ?string
+    {
+        return $this->actionMethod;
+    }
+
+    public function getParameters(): array
     {
         return $this->parameters;
     }
 
     /**
-     * @param string $name
      * @param mixed $default
      * @return mixed
      */
-    public function getParameter($name, $default = null)
+    public function getParameter(string $name, $default = null)
     {
-        return array_key_exists($name, $this->parameters) ? $this->parameters[$name] : $default;
+        return $this->parameters[$name] ?? $default;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getControllerClass()
-    {
-        return $this->controllerClass;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getActionMethod()
-    {
-        return $this->actionMethod;
-    }
-
-    /**
-     * @return array
-     */
-    public function getMiddlewares()
+    public function getMiddlewares(): array
     {
         return $this->middlewares;
     }
 
     /**
-     * @return bool
+     * @deprecated Legacy convention-based routing field.
      */
-    public function isAnnotated()
+    public function getModuleName(): ?string
     {
-        return $this->controllerClass !== null;
+        return $this->moduleName;
+    }
+
+    /**
+     * @deprecated Legacy convention-based routing field.
+     */
+    public function getControllerName(): ?string
+    {
+        return $this->controllerName;
+    }
+
+    /**
+     * @deprecated Legacy convention-based routing field.
+     */
+    public function getActionName(): ?string
+    {
+        return $this->actionName;
     }
 }

--- a/lib/Ngames/Framework/Router/Route.php
+++ b/lib/Ngames/Framework/Router/Route.php
@@ -46,6 +46,7 @@ class Route
 
     private function __construct()
     {
+        // Private: use Route::create() or Route::createLegacy() named constructors
     }
 
     /**

--- a/lib/Ngames/Framework/Router/RouteCollector.php
+++ b/lib/Ngames/Framework/Router/RouteCollector.php
@@ -1,0 +1,235 @@
+<?php
+
+namespace Ngames\Framework\Router;
+
+use Ngames\Framework\Router\Attribute\Delete;
+use Ngames\Framework\Router\Attribute\Get;
+use Ngames\Framework\Router\Attribute\Middleware;
+use Ngames\Framework\Router\Attribute\Post;
+use Ngames\Framework\Router\Attribute\Put;
+use Ngames\Framework\Router\Attribute\Route as RouteAttribute;
+
+class RouteCollector
+{
+    private const HTTP_METHOD_ATTRIBUTES = [
+        Get::class => 'GET',
+        Post::class => 'POST',
+        Put::class => 'PUT',
+        Delete::class => 'DELETE',
+    ];
+
+    private string $cachePrefix;
+
+    private bool $apcuWarningLogged = false;
+
+    public function __construct(string $cachePrefix = 'ngames_routes')
+    {
+        $this->cachePrefix = $cachePrefix;
+    }
+
+    /**
+     * Collect annotated routes from the given directories and register them on the router.
+     *
+     * @param array $directories
+     * @param Router $router
+     */
+    public function collect(array $directories, Router $router): void
+    {
+        $routes = $this->loadRoutes($directories);
+
+        foreach ($routes as $routeData) {
+            $matcher = new Matcher(
+                $routeData['pattern'],
+                null,
+                null,
+                null,
+                $routeData['name'],
+                $routeData['method'],
+                $routeData['controllerClass'],
+                $routeData['actionMethod'],
+                $routeData['middlewares']
+            );
+            $router->addMatcher($matcher);
+        }
+    }
+
+    /**
+     * Clear the APCu cache.
+     */
+    public function clearCache(): void
+    {
+        if (function_exists('apcu_delete')) {
+            apcu_delete($this->getCacheKey());
+        }
+    }
+
+    /**
+     * Load routes, using APCu cache if available.
+     *
+     * @param array $directories
+     * @return array
+     */
+    private function loadRoutes(array $directories): array
+    {
+        $cacheKey = $this->getCacheKey();
+
+        // Try APCu cache
+        if (function_exists('apcu_fetch') && function_exists('apcu_enabled') && apcu_enabled()) {
+            $cached = apcu_fetch($cacheKey, $success);
+            if ($success) {
+                return $cached;
+            }
+
+            $routes = $this->scanDirectories($directories);
+            apcu_store($cacheKey, $routes);
+            return $routes;
+        }
+
+        // APCu not available — log warning once
+        if (!$this->apcuWarningLogged) {
+            $this->apcuWarningLogged = true;
+            \Ngames\Framework\Logger::logWarning('APCu is not available, route caching disabled. Routes will be scanned on every request.');
+        }
+
+        return $this->scanDirectories($directories);
+    }
+
+    /**
+     * Scan directories for annotated controller classes.
+     *
+     * @param array $directories
+     * @return array
+     */
+    private function scanDirectories(array $directories): array
+    {
+        $routes = [];
+
+        foreach ($directories as $directory) {
+            if (!is_dir($directory)) {
+                continue;
+            }
+            $this->scanDirectory($directory, $routes);
+        }
+
+        return $routes;
+    }
+
+    /**
+     * Recursively scan a directory for PHP files.
+     *
+     * @param string $directory
+     * @param array &$routes
+     */
+    private function scanDirectory(string $directory, array &$routes): void
+    {
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($directory, \RecursiveDirectoryIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $className = $this->getClassNameFromFile($file->getPathname());
+            if ($className === null || !class_exists($className)) {
+                continue;
+            }
+
+            $this->processClass($className, $routes);
+        }
+    }
+
+    /**
+     * Extract the fully qualified class name from a PHP file.
+     *
+     * @param string $filePath
+     * @return string|null
+     */
+    private function getClassNameFromFile(string $filePath): ?string
+    {
+        $contents = file_get_contents($filePath);
+        $namespace = null;
+        $class = null;
+
+        if (preg_match('/namespace\s+([^;]+);/', $contents, $matches)) {
+            $namespace = $matches[1];
+        }
+
+        if (preg_match('/class\s+(\w+)/', $contents, $matches)) {
+            $class = $matches[1];
+        }
+
+        if ($class === null) {
+            return null;
+        }
+
+        return $namespace !== null ? $namespace . '\\' . $class : $class;
+    }
+
+    /**
+     * Process a class for route attributes.
+     *
+     * @param string $className
+     * @param array &$routes
+     */
+    private function processClass(string $className, array &$routes): void
+    {
+        $reflectionClass = new \ReflectionClass($className);
+        $routeAttributes = $reflectionClass->getAttributes(RouteAttribute::class);
+
+        if (empty($routeAttributes)) {
+            return;
+        }
+
+        $routeAttribute = $routeAttributes[0]->newInstance();
+        $basePath = $routeAttribute->path;
+
+        // Collect class-level middleware
+        $classMiddlewares = [];
+        foreach ($reflectionClass->getAttributes(Middleware::class) as $attr) {
+            $classMiddlewares[] = $attr->newInstance()->class;
+        }
+
+        // Process methods
+        foreach ($reflectionClass->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+            foreach (self::HTTP_METHOD_ATTRIBUTES as $attributeClass => $httpMethod) {
+                $methodAttributes = $method->getAttributes($attributeClass);
+
+                foreach ($methodAttributes as $methodAttribute) {
+                    $attr = $methodAttribute->newInstance();
+                    $fullPath = rtrim($basePath, '/') . '/' . ltrim($attr->path, '/');
+                    $fullPath = rtrim($fullPath, '/');
+                    if ($fullPath === '') {
+                        $fullPath = '/';
+                    }
+
+                    // Collect method-level middleware
+                    $methodMiddlewares = [];
+                    foreach ($method->getAttributes(Middleware::class) as $mwAttr) {
+                        $methodMiddlewares[] = $mwAttr->newInstance()->class;
+                    }
+
+                    $allMiddlewares = array_merge($classMiddlewares, $methodMiddlewares);
+
+                    $routes[] = [
+                        'pattern' => $fullPath,
+                        'method' => $httpMethod,
+                        'controllerClass' => $className,
+                        'actionMethod' => $method->getName(),
+                        'middlewares' => $allMiddlewares,
+                        'name' => null,
+                    ];
+                }
+            }
+        }
+    }
+
+    /**
+     * @return string
+     */
+    private function getCacheKey(): string
+    {
+        return $this->cachePrefix . '_compiled';
+    }
+}

--- a/lib/Ngames/Framework/Router/RouteCollector.php
+++ b/lib/Ngames/Framework/Router/RouteCollector.php
@@ -40,12 +40,8 @@ class RouteCollector
         $routes = $this->loadRoutes($directories);
 
         foreach ($routes as $routeData) {
-            $matcher = new Matcher(
+            $matcher = Matcher::forAnnotatedRoute(
                 $routeData['pattern'],
-                null,
-                null,
-                null,
-                $routeData['name'],
                 $routeData['method'],
                 $routeData['controllerClass'],
                 $routeData['actionMethod'],
@@ -195,34 +191,34 @@ class RouteCollector
 
         // Process methods
         foreach ($reflectionClass->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
-            foreach (self::HTTP_METHOD_ATTRIBUTES as $attributeClass => $httpMethod) {
-                $methodAttributes = $method->getAttributes($attributeClass);
+            $this->processMethod($method, $basePath, $className, $classMiddlewares, $routes);
+        }
+    }
 
-                foreach ($methodAttributes as $methodAttribute) {
-                    $attr = $methodAttribute->newInstance();
-                    $fullPath = rtrim($basePath, '/') . '/' . ltrim($attr->path, '/');
-                    $fullPath = rtrim($fullPath, '/');
-                    if ($fullPath === '') {
-                        $fullPath = '/';
-                    }
+    /**
+     * Process a single method for HTTP method attributes.
+     */
+    private function processMethod(\ReflectionMethod $method, string $basePath, string $className, array $classMiddlewares, array &$routes): void
+    {
+        $methodMiddlewares = [];
+        foreach ($method->getAttributes(Middleware::class) as $mwAttr) {
+            $methodMiddlewares[] = $mwAttr->newInstance()->class;
+        }
+        $allMiddlewares = array_merge($classMiddlewares, $methodMiddlewares);
 
-                    // Collect method-level middleware
-                    $methodMiddlewares = [];
-                    foreach ($method->getAttributes(Middleware::class) as $mwAttr) {
-                        $methodMiddlewares[] = $mwAttr->newInstance()->class;
-                    }
+        foreach (self::HTTP_METHOD_ATTRIBUTES as $attributeClass => $httpMethod) {
+            foreach ($method->getAttributes($attributeClass) as $methodAttribute) {
+                $fullPath = rtrim($basePath, '/') . '/' . ltrim($methodAttribute->newInstance()->path, '/');
+                $fullPath = rtrim($fullPath, '/') ?: '/';
 
-                    $allMiddlewares = array_merge($classMiddlewares, $methodMiddlewares);
-
-                    $routes[] = [
-                        'pattern' => $fullPath,
-                        'method' => $httpMethod,
-                        'controllerClass' => $className,
-                        'actionMethod' => $method->getName(),
-                        'middlewares' => $allMiddlewares,
-                        'name' => null,
-                    ];
-                }
+                $routes[] = [
+                    'pattern' => $fullPath,
+                    'method' => $httpMethod,
+                    'controllerClass' => $className,
+                    'actionMethod' => $method->getName(),
+                    'middlewares' => $allMiddlewares,
+                    'name' => null,
+                ];
             }
         }
     }

--- a/lib/Ngames/Framework/Router/RouteCollector.php
+++ b/lib/Ngames/Framework/Router/RouteCollector.php
@@ -5,6 +5,7 @@ namespace Ngames\Framework\Router;
 use Ngames\Framework\Router\Attribute\Delete;
 use Ngames\Framework\Router\Attribute\Get;
 use Ngames\Framework\Router\Attribute\Middleware;
+use Ngames\Framework\Router\Attribute\Patch;
 use Ngames\Framework\Router\Attribute\Post;
 use Ngames\Framework\Router\Attribute\Put;
 use Ngames\Framework\Router\Attribute\Route as RouteAttribute;
@@ -15,6 +16,7 @@ class RouteCollector
         Get::class => 'GET',
         Post::class => 'POST',
         Put::class => 'PUT',
+        Patch::class => 'PATCH',
         Delete::class => 'DELETE',
     ];
 

--- a/lib/Ngames/Framework/Router/RouteCollector.php
+++ b/lib/Ngames/Framework/Router/RouteCollector.php
@@ -40,14 +40,13 @@ class RouteCollector
         $routes = $this->loadRoutes($directories);
 
         foreach ($routes as $routeData) {
-            $matcher = Matcher::forAnnotatedRoute(
+            $router->addMatcher(new Matcher(
                 $routeData['pattern'],
                 $routeData['method'],
                 $routeData['controllerClass'],
                 $routeData['actionMethod'],
                 $routeData['middlewares']
-            );
-            $router->addMatcher($matcher);
+            ));
         }
     }
 

--- a/lib/Ngames/Framework/Router/Router.php
+++ b/lib/Ngames/Framework/Router/Router.php
@@ -89,14 +89,15 @@ class Router
     /**
      *
      * @param string $uri
+     * @param string|null $method
      * @return Route|null the found route if any, null otherwise
      */
-    public function getRoute($uri)
+    public function getRoute($uri, $method = null)
     {
         $result = null;
 
         foreach ($this->matchers as $matcher) {
-            $matchedRoute = $matcher->match($uri);
+            $matchedRoute = $matcher->match($uri, $method);
             if ($matchedRoute !== null) {
                 $result = $matchedRoute;
                 break;

--- a/tests/Ngames/Framework/Tests/ApplicationTest.php
+++ b/tests/Ngames/Framework/Tests/ApplicationTest.php
@@ -106,7 +106,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
     {
         require_once __DIR__ . '/DummyController.php';
         $application = Application::initialize(ROOT_DIR . '/tests/data/Application/config.ini');
-        $application->getRouter()->addMatcher(new Matcher('/', 'application', 'dummy', 'index'));
+        $application->getRouter()->addMatcher(@Matcher::forConventionRoute('/', 'application', 'dummy', 'index'));
         ob_start();
         $application->run();
         $this->assertEquals('index', ob_get_contents());
@@ -118,7 +118,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
     {
         require_once __DIR__ . '/DummyController.php';
         $application = Application::initialize(ROOT_DIR . '/tests/data/Application/config.ini');
-        $application->getRouter()->addMatcher(new Matcher('/test', 'application', 'dummy', 'index'));
+        $application->getRouter()->addMatcher(@Matcher::forConventionRoute('/test', 'application', 'dummy', 'index'));
         ob_start();
         $application->run();
         $this->assertEquals('File not found.', ob_get_contents());
@@ -130,7 +130,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
     {
         require_once __DIR__ . '/DummyController.php';
         $application = Application::initialize(ROOT_DIR . '/tests/data/Application/config.ini');
-        $application->getRouter()->addMatcher(new Matcher('/', 'application', 'dummy', 'output-string'));
+        $application->getRouter()->addMatcher(@Matcher::forConventionRoute('/', 'application', 'dummy', 'output-string'));
         ob_start();
         $application->run();
         $this->assertEquals('output_string', ob_get_contents());
@@ -142,7 +142,7 @@ class ApplicationTest extends \PHPUnit\Framework\TestCase
     {
         require_once __DIR__ . '/DummyController.php';
         $application = Application::initialize(ROOT_DIR . '/tests/data/Application/config.ini');
-        $application->getRouter()->addMatcher(new Matcher('/', 'application', 'dummy', 'output-null'));
+        $application->getRouter()->addMatcher(@Matcher::forConventionRoute('/', 'application', 'dummy', 'output-null'));
         ob_start();
         $application->run();
         $this->assertEquals('Internal server error.', ob_get_contents());

--- a/tests/Ngames/Framework/Tests/ControllerTest.php
+++ b/tests/Ngames/Framework/Tests/ControllerTest.php
@@ -135,7 +135,7 @@ class ControllerTest extends \PHPUnit\Framework\TestCase
 
     public function testExecute()
     {
-        $route = new Route('application', 'dummy', 'index');
+        $route = Route::createLegacy('application', 'dummy', 'index');
         $request = new Request();
         ob_start();
         Controller::execute($route, $request)->send();
@@ -146,7 +146,7 @@ class ControllerTest extends \PHPUnit\Framework\TestCase
 
     public function testForward()
     {
-        $route = new Route('application', 'dummy', 'forward');
+        $route = Route::createLegacy('application', 'dummy', 'forward');
         $request = new Request();
         ob_start();
         Controller::execute($route, $request)->send();
@@ -159,7 +159,7 @@ class ControllerTest extends \PHPUnit\Framework\TestCase
     {
         // Application instance needed for the configuration
         Application::initialize(ROOT_DIR . '/tests/data/Application/config.ini');
-        $route = new Route('application', 'dummy', 'does_not_exist');
+        $route = Route::createLegacy('application', 'dummy', 'does_not_exist');
         $request = new Request();
         ob_start();
         Controller::execute($route, $request)->send();

--- a/tests/Ngames/Framework/Tests/Database/AbstractDatabaseTestCase.php
+++ b/tests/Ngames/Framework/Tests/Database/AbstractDatabaseTestCase.php
@@ -29,7 +29,7 @@ use Ngames\Framework\Database\Connection;
 /**
  * Common test case class for all tests involving a database
  */
-class AbstractDatabaseTestCase extends \PHPUnit\Framework\TestCase
+abstract class AbstractDatabaseTestCase extends \PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass(): void
     {

--- a/tests/Ngames/Framework/Tests/Fixtures/TestAnnotatedController.php
+++ b/tests/Ngames/Framework/Tests/Fixtures/TestAnnotatedController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Ngames\Framework\Tests\Fixtures;
+
+use Ngames\Framework\Controller;
+use Ngames\Framework\Router\Attribute\Delete;
+use Ngames\Framework\Router\Attribute\Get;
+use Ngames\Framework\Router\Attribute\Middleware;
+use Ngames\Framework\Router\Attribute\Post;
+use Ngames\Framework\Router\Attribute\Route;
+
+#[Route('/api/v1/alliances')]
+#[Middleware(TestClassMiddleware::class)]
+class TestAnnotatedController extends Controller
+{
+    #[Get]
+    public function listAction()
+    {
+        return $this->ok('list');
+    }
+
+    #[Get('/:id')]
+    public function showAction(int $id)
+    {
+        return $this->json(['id' => $id]);
+    }
+
+    #[Delete('/:id')]
+    #[Middleware(TestMethodMiddleware::class)]
+    public function deleteAction(int $id)
+    {
+        return $this->json(['deleted' => $id]);
+    }
+
+    #[Post('/:id/members/:userId/accept')]
+    public function acceptAction(int $id, int $userId)
+    {
+        return $this->json(['id' => $id, 'userId' => $userId]);
+    }
+
+    #[Get('/:id/details')]
+    public function detailsAction(int $id, string $format = 'json')
+    {
+        return $this->json(['id' => $id, 'format' => $format]);
+    }
+
+    #[Get('/:id/score')]
+    public function scoreAction(float $id)
+    {
+        return $this->json(['id' => $id]);
+    }
+
+    #[Get('/:id/active')]
+    public function activeAction(bool $id)
+    {
+        return $this->json(['id' => $id]);
+    }
+}

--- a/tests/Ngames/Framework/Tests/Fixtures/TestAnnotatedController.php
+++ b/tests/Ngames/Framework/Tests/Fixtures/TestAnnotatedController.php
@@ -6,6 +6,7 @@ use Ngames\Framework\Controller;
 use Ngames\Framework\Router\Attribute\Delete;
 use Ngames\Framework\Router\Attribute\Get;
 use Ngames\Framework\Router\Attribute\Middleware;
+use Ngames\Framework\Router\Attribute\Patch;
 use Ngames\Framework\Router\Attribute\Post;
 use Ngames\Framework\Router\Attribute\Route;
 
@@ -54,5 +55,11 @@ class TestAnnotatedController extends Controller
     public function activeAction(bool $id)
     {
         return $this->json(['id' => $id]);
+    }
+
+    #[Patch('/:id')]
+    public function updateAction(int $id)
+    {
+        return $this->json(['patched' => $id]);
     }
 }

--- a/tests/Ngames/Framework/Tests/Fixtures/TestClassMiddleware.php
+++ b/tests/Ngames/Framework/Tests/Fixtures/TestClassMiddleware.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Ngames\Framework\Tests\Fixtures;
+
+use Ngames\Framework\Request;
+use Ngames\Framework\Response;
+use Ngames\Framework\Router\MiddlewareInterface;
+
+class TestClassMiddleware implements MiddlewareInterface
+{
+    public function handle(Request $request, callable $next): Response
+    {
+        $response = $next($request);
+        $response->setHeader('X-Class-Middleware', 'applied');
+        return $response;
+    }
+}

--- a/tests/Ngames/Framework/Tests/Fixtures/TestMethodMiddleware.php
+++ b/tests/Ngames/Framework/Tests/Fixtures/TestMethodMiddleware.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Ngames\Framework\Tests\Fixtures;
+
+use Ngames\Framework\Request;
+use Ngames\Framework\Response;
+use Ngames\Framework\Router\MiddlewareInterface;
+
+class TestMethodMiddleware implements MiddlewareInterface
+{
+    public function handle(Request $request, callable $next): Response
+    {
+        $response = $next($request);
+        $response->setHeader('X-Method-Middleware', 'applied');
+        return $response;
+    }
+}

--- a/tests/Ngames/Framework/Tests/Fixtures/TestNoAttributeController.php
+++ b/tests/Ngames/Framework/Tests/Fixtures/TestNoAttributeController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Ngames\Framework\Tests\Fixtures;
+
+use Ngames\Framework\Controller;
+
+class TestNoAttributeController extends Controller
+{
+    public function indexAction()
+    {
+        return $this->ok('index');
+    }
+}

--- a/tests/Ngames/Framework/Tests/Fixtures/TestShortCircuitController.php
+++ b/tests/Ngames/Framework/Tests/Fixtures/TestShortCircuitController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Ngames\Framework\Tests\Fixtures;
+
+use Ngames\Framework\Controller;
+use Ngames\Framework\Router\Attribute\Get;
+use Ngames\Framework\Router\Attribute\Middleware;
+use Ngames\Framework\Router\Attribute\Route;
+
+#[Route('/api/v1/blocked')]
+#[Middleware(TestShortCircuitMiddleware::class)]
+class TestShortCircuitController extends Controller
+{
+    #[Get]
+    public function indexAction()
+    {
+        return $this->ok('should not reach here');
+    }
+}

--- a/tests/Ngames/Framework/Tests/Fixtures/TestShortCircuitMiddleware.php
+++ b/tests/Ngames/Framework/Tests/Fixtures/TestShortCircuitMiddleware.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Ngames\Framework\Tests\Fixtures;
+
+use Ngames\Framework\Request;
+use Ngames\Framework\Response;
+use Ngames\Framework\Router\MiddlewareInterface;
+
+class TestShortCircuitMiddleware implements MiddlewareInterface
+{
+    public function handle(Request $request, callable $next): Response
+    {
+        return Response::createUnauthorizedResponse('Blocked by middleware');
+    }
+}

--- a/tests/Ngames/Framework/Tests/IntegrationTest.php
+++ b/tests/Ngames/Framework/Tests/IntegrationTest.php
@@ -89,7 +89,7 @@ class IntegrationTest extends TestCase
         $collector->collect([__DIR__ . '/Fixtures'], $router);
 
         // Add a convention matcher after annotated routes
-        $router->addMatcher(new \Ngames\Framework\Router\Matcher('/:module/:controller/:action'));
+        $router->addMatcher(@\Ngames\Framework\Router\Matcher::forConventionRoute('/:module/:controller/:action'));
 
         // Annotated route should match
         $route = $router->getRoute('/api/v1/alliances', 'GET');

--- a/tests/Ngames/Framework/Tests/IntegrationTest.php
+++ b/tests/Ngames/Framework/Tests/IntegrationTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Ngames\Framework\Tests;
+
+use Ngames\Framework\Application;
+use Ngames\Framework\Controller;
+use Ngames\Framework\Request;
+use Ngames\Framework\Router\RouteCollector;
+use Ngames\Framework\Router\Router;
+use Ngames\Framework\Tests\Fixtures\TestAnnotatedController;
+use PHPUnit\Framework\TestCase;
+
+class IntegrationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $reflection = new \ReflectionClass(Application::class);
+        $instance = $reflection->getProperty('instance');
+        $instance->setValue(null, null);
+
+        Application::initialize(ROOT_DIR . '/tests/data/Application/config.ini');
+    }
+
+    protected function tearDown(): void
+    {
+        $reflection = new \ReflectionClass(Application::class);
+        $instance = $reflection->getProperty('instance');
+        $instance->setValue(null, null);
+    }
+
+    public function testFullFlowWithRouteCollectorAndDispatch()
+    {
+        $router = new Router();
+        $collector = new RouteCollector();
+        $collector->collect([__DIR__ . '/Fixtures'], $router);
+
+        // Match the route
+        $route = $router->getRoute('/api/v1/alliances/42', 'GET');
+        $this->assertNotNull($route);
+        $this->assertTrue($route->isAnnotated());
+        $this->assertEquals(TestAnnotatedController::class, $route->getControllerClass());
+        $this->assertEquals('showAction', $route->getActionMethod());
+        $this->assertEquals(['id' => '42'], $route->getParameters());
+
+        // Dispatch through Controller
+        $request = new Request();
+        $result = Controller::execute($route, $request);
+        ob_start();
+        $result->send();
+        $content = ob_get_contents();
+        ob_end_clean();
+
+        $decoded = json_decode($content, true);
+        $this->assertSame(42, $decoded['id']);
+    }
+
+    public function testFullFlowWithMiddleware()
+    {
+        $router = new Router();
+        $collector = new RouteCollector();
+        $collector->collect([__DIR__ . '/Fixtures'], $router);
+
+        // DELETE route has class + method middleware
+        $route = $router->getRoute('/api/v1/alliances/42', 'DELETE');
+        $this->assertNotNull($route);
+
+        $request = new Request();
+        $result = Controller::execute($route, $request);
+
+        // Verify middleware ran
+        $headers = $result->getHeaders();
+        $this->assertEquals('applied', $headers['X-Class-Middleware']);
+        $this->assertEquals('applied', $headers['X-Method-Middleware']);
+
+        // Verify correct action called with typed parameter
+        ob_start();
+        $result->send();
+        $content = ob_get_contents();
+        ob_end_clean();
+
+        $decoded = json_decode($content, true);
+        $this->assertSame(42, $decoded['deleted']);
+    }
+
+    public function testAnnotatedRoutesCoexistWithConventionRoutes()
+    {
+        $router = new Router();
+        $collector = new RouteCollector();
+        $collector->collect([__DIR__ . '/Fixtures'], $router);
+
+        // Add a convention matcher after annotated routes
+        $router->addMatcher(new \Ngames\Framework\Router\Matcher('/:module/:controller/:action'));
+
+        // Annotated route should match
+        $route = $router->getRoute('/api/v1/alliances', 'GET');
+        $this->assertNotNull($route);
+        $this->assertTrue($route->isAnnotated());
+
+        // Convention route should still work
+        $route = $router->getRoute('/app/home/index', 'GET');
+        $this->assertNotNull($route);
+        $this->assertFalse($route->isAnnotated());
+        $this->assertEquals('app', $route->getModuleName());
+    }
+
+    public function testShortCircuitMiddlewarePreventsAction()
+    {
+        $router = new Router();
+        $collector = new RouteCollector();
+        $collector->collect([__DIR__ . '/Fixtures'], $router);
+
+        $route = $router->getRoute('/api/v1/blocked', 'GET');
+        $this->assertNotNull($route);
+
+        $request = new Request();
+        $result = Controller::execute($route, $request);
+
+        ob_start();
+        $result->send();
+        $content = ob_get_contents();
+        ob_end_clean();
+
+        $this->assertEquals(401, http_response_code());
+        $this->assertEquals('Blocked by middleware', $content);
+    }
+}

--- a/tests/Ngames/Framework/Tests/LoggerTest.php
+++ b/tests/Ngames/Framework/Tests/LoggerTest.php
@@ -28,26 +28,17 @@ use Ngames\Framework\Logger;
 
 class LoggerTest extends \PHPUnit\Framework\TestCase
 {
-    private $expectedMessages = array();
-
-    private $notExpectedMessages = array();
-
     public function setUp(): void
     {
         ob_start();
     }
 
-    public function tearDown(): void
+    private function getCapturedOutput(): string
     {
         $output = ob_get_contents();
         ob_end_clean();
 
-        foreach ($this->expectedMessages as $expectedMessage) {
-            $this->assertStringContainsString($expectedMessage, $output);
-        }
-        foreach ($this->notExpectedMessages as $notExpectedMessage) {
-            $this->assertStringNotContainsString($notExpectedMessage, $output);
-        }
+        return $output;
     }
 
     public function testInitialize()
@@ -57,18 +48,16 @@ class LoggerTest extends \PHPUnit\Framework\TestCase
         Logger::logInfo('info message');
         Logger::logWarning('warning message');
         Logger::logError('error message');
-        $this->expectedMessages = array(
-            'info message',
-            'warning message',
-            'error message'
-        );
-        $this->notExpectedMessages = array(
-            'debug message'
-        );
+        $output = $this->getCapturedOutput();
+        $this->assertStringContainsString('info message', $output);
+        $this->assertStringContainsString('warning message', $output);
+        $this->assertStringContainsString('error message', $output);
+        $this->assertStringNotContainsString('debug message', $output);
     }
 
     public function testSetDestination_error()
     {
+        ob_end_clean();
         $this->expectException('\Ngames\Framework\Exception');
         $this->expectExceptionMessage('Cannot open log file for writing');
         Logger::setDestination('\\//');
@@ -82,13 +71,11 @@ class LoggerTest extends \PHPUnit\Framework\TestCase
         Logger::logInfo('info message');
         Logger::logWarning('warning message');
         Logger::logError('error message');
-        $this->expectedMessages = array(
-            'debug message',
-            'info message',
-            'warning message',
-            'error message'
-        );
-        $this->notExpectedMessages = array();
+        $output = $this->getCapturedOutput();
+        $this->assertStringContainsString('debug message', $output);
+        $this->assertStringContainsString('info message', $output);
+        $this->assertStringContainsString('warning message', $output);
+        $this->assertStringContainsString('error message', $output);
     }
 
     public function test_minLevelInfo()
@@ -99,14 +86,11 @@ class LoggerTest extends \PHPUnit\Framework\TestCase
         Logger::logInfo('info message');
         Logger::logWarning('warning message');
         Logger::logError('error message');
-        $this->expectedMessages = array(
-            'info message',
-            'warning message',
-            'error message'
-        );
-        $this->notExpectedMessages = array(
-            'debug message'
-        );
+        $output = $this->getCapturedOutput();
+        $this->assertStringContainsString('info message', $output);
+        $this->assertStringContainsString('warning message', $output);
+        $this->assertStringContainsString('error message', $output);
+        $this->assertStringNotContainsString('debug message', $output);
     }
 
     public function test_minLevelWarning()
@@ -117,14 +101,11 @@ class LoggerTest extends \PHPUnit\Framework\TestCase
         Logger::logInfo('info message');
         Logger::logWarning('warning message');
         Logger::logError('error message');
-        $this->expectedMessages = array(
-            'warning message',
-            'error message'
-        );
-        $this->notExpectedMessages = array(
-            'debug message',
-            'info message'
-        );
+        $output = $this->getCapturedOutput();
+        $this->assertStringContainsString('warning message', $output);
+        $this->assertStringContainsString('error message', $output);
+        $this->assertStringNotContainsString('debug message', $output);
+        $this->assertStringNotContainsString('info message', $output);
     }
 
     public function test_minLevelError()
@@ -135,14 +116,11 @@ class LoggerTest extends \PHPUnit\Framework\TestCase
         Logger::logInfo('info message');
         Logger::logWarning('warning message');
         Logger::logError('error message');
-        $this->expectedMessages = array(
-            'error message'
-        );
-        $this->notExpectedMessages = array(
-            'debug message',
-            'info message',
-            'warning message'
-        );
+        $output = $this->getCapturedOutput();
+        $this->assertStringContainsString('error message', $output);
+        $this->assertStringNotContainsString('debug message', $output);
+        $this->assertStringNotContainsString('info message', $output);
+        $this->assertStringNotContainsString('warning message', $output);
     }
 
     public function test_logFormat()
@@ -151,8 +129,10 @@ class LoggerTest extends \PHPUnit\Framework\TestCase
         Logger::setMinLevel(Logger::LEVEL_DEBUG);
         Logger::logDebug('debug message');
         $lineNumber = __LINE__ - 1;
-        $this->expectedMessages = array(
-            '[DEBUG] ' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'Ngames' . DIRECTORY_SEPARATOR . 'Framework' . DIRECTORY_SEPARATOR . 'Tests' . DIRECTORY_SEPARATOR . 'LoggerTest.php:' . $lineNumber . ' - debug message'
+        $output = $this->getCapturedOutput();
+        $this->assertStringContainsString(
+            '[DEBUG] ' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'Ngames' . DIRECTORY_SEPARATOR . 'Framework' . DIRECTORY_SEPARATOR . 'Tests' . DIRECTORY_SEPARATOR . 'LoggerTest.php:' . $lineNumber . ' - debug message',
+            $output
         );
     }
 }

--- a/tests/Ngames/Framework/Tests/ParameterInjectionTest.php
+++ b/tests/Ngames/Framework/Tests/ParameterInjectionTest.php
@@ -29,7 +29,7 @@ class ParameterInjectionTest extends TestCase
 
     public function testIntIdReceivesInteger()
     {
-        $route = new Route(null, null, null, ['id' => '42'], TestAnnotatedController::class, 'showAction', []);
+        $route = Route::create(TestAnnotatedController::class, 'showAction', ['id' => '42']);
         $request = new Request();
         $result = Controller::execute($route, $request);
         ob_start();
@@ -43,15 +43,7 @@ class ParameterInjectionTest extends TestCase
 
     public function testMultipleParameters()
     {
-        $route = new Route(
-            null,
-            null,
-            null,
-            ['id' => '42', 'userId' => '7'],
-            TestAnnotatedController::class,
-            'acceptAction',
-            []
-        );
+        $route = Route::create(TestAnnotatedController::class, 'acceptAction', ['id' => '42', 'userId' => '7']);
         $request = new Request();
         $result = Controller::execute($route, $request);
         ob_start();
@@ -66,7 +58,7 @@ class ParameterInjectionTest extends TestCase
 
     public function testNoParametersWorksAsBeforeForAnnotated()
     {
-        $route = new Route(null, null, null, [], TestAnnotatedController::class, 'listAction', []);
+        $route = Route::create(TestAnnotatedController::class, 'listAction');
         $request = new Request();
         $result = Controller::execute($route, $request);
         ob_start();
@@ -80,7 +72,7 @@ class ParameterInjectionTest extends TestCase
     public function testMissingRequiredParameterReturns400()
     {
         // showAction requires int $id but we provide no parameters
-        $route = new Route(null, null, null, [], TestAnnotatedController::class, 'showAction', []);
+        $route = Route::create(TestAnnotatedController::class, 'showAction');
         $request = new Request();
         $result = Controller::execute($route, $request);
         ob_start();
@@ -92,15 +84,7 @@ class ParameterInjectionTest extends TestCase
     public function testOptionalParameterUsesDefault()
     {
         // detailsAction(int $id, string $format = 'json')
-        $route = new Route(
-            null,
-            null,
-            null,
-            ['id' => '42'],
-            TestAnnotatedController::class,
-            'detailsAction',
-            []
-        );
+        $route = Route::create(TestAnnotatedController::class, 'detailsAction', ['id' => '42']);
         $request = new Request();
         $result = Controller::execute($route, $request);
         ob_start();
@@ -116,15 +100,7 @@ class ParameterInjectionTest extends TestCase
     public function testFloatCasting()
     {
         // scoreAction(float $id)
-        $route = new Route(
-            null,
-            null,
-            null,
-            ['id' => '3.14'],
-            TestAnnotatedController::class,
-            'scoreAction',
-            []
-        );
+        $route = Route::create(TestAnnotatedController::class, 'scoreAction', ['id' => '3.14']);
         $request = new Request();
         $result = Controller::execute($route, $request);
         ob_start();
@@ -139,15 +115,7 @@ class ParameterInjectionTest extends TestCase
     public function testBoolCasting()
     {
         // activeAction(bool $id)
-        $route = new Route(
-            null,
-            null,
-            null,
-            ['id' => 'true'],
-            TestAnnotatedController::class,
-            'activeAction',
-            []
-        );
+        $route = Route::create(TestAnnotatedController::class, 'activeAction', ['id' => 'true']);
         $request = new Request();
         $result = Controller::execute($route, $request);
         ob_start();

--- a/tests/Ngames/Framework/Tests/ParameterInjectionTest.php
+++ b/tests/Ngames/Framework/Tests/ParameterInjectionTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Ngames\Framework\Tests;
+
+use Ngames\Framework\Application;
+use Ngames\Framework\Controller;
+use Ngames\Framework\Request;
+use Ngames\Framework\Router\Route;
+use Ngames\Framework\Tests\Fixtures\TestAnnotatedController;
+use PHPUnit\Framework\TestCase;
+
+class ParameterInjectionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $reflection = new \ReflectionClass(Application::class);
+        $instance = $reflection->getProperty('instance');
+        $instance->setValue(null, null);
+
+        Application::initialize(ROOT_DIR . '/tests/data/Application/config.ini');
+    }
+
+    protected function tearDown(): void
+    {
+        $reflection = new \ReflectionClass(Application::class);
+        $instance = $reflection->getProperty('instance');
+        $instance->setValue(null, null);
+    }
+
+    public function testIntIdReceivesInteger()
+    {
+        $route = new Route(null, null, null, ['id' => '42'], TestAnnotatedController::class, 'showAction', []);
+        $request = new Request();
+        $result = Controller::execute($route, $request);
+        ob_start();
+        $result->send();
+        $content = ob_get_contents();
+        ob_end_clean();
+
+        $decoded = json_decode($content, true);
+        $this->assertSame(42, $decoded['id']);
+    }
+
+    public function testMultipleParameters()
+    {
+        $route = new Route(
+            null,
+            null,
+            null,
+            ['id' => '42', 'userId' => '7'],
+            TestAnnotatedController::class,
+            'acceptAction',
+            []
+        );
+        $request = new Request();
+        $result = Controller::execute($route, $request);
+        ob_start();
+        $result->send();
+        $content = ob_get_contents();
+        ob_end_clean();
+
+        $decoded = json_decode($content, true);
+        $this->assertSame(42, $decoded['id']);
+        $this->assertSame(7, $decoded['userId']);
+    }
+
+    public function testNoParametersWorksAsBeforeForAnnotated()
+    {
+        $route = new Route(null, null, null, [], TestAnnotatedController::class, 'listAction', []);
+        $request = new Request();
+        $result = Controller::execute($route, $request);
+        ob_start();
+        $result->send();
+        $content = ob_get_contents();
+        ob_end_clean();
+
+        $this->assertEquals('list', $content);
+    }
+
+    public function testMissingRequiredParameterReturns400()
+    {
+        // showAction requires int $id but we provide no parameters
+        $route = new Route(null, null, null, [], TestAnnotatedController::class, 'showAction', []);
+        $request = new Request();
+        $result = Controller::execute($route, $request);
+        ob_start();
+        $result->send();
+        ob_end_clean();
+        $this->assertEquals(400, http_response_code());
+    }
+
+    public function testOptionalParameterUsesDefault()
+    {
+        // detailsAction(int $id, string $format = 'json')
+        $route = new Route(
+            null,
+            null,
+            null,
+            ['id' => '42'],
+            TestAnnotatedController::class,
+            'detailsAction',
+            []
+        );
+        $request = new Request();
+        $result = Controller::execute($route, $request);
+        ob_start();
+        $result->send();
+        $content = ob_get_contents();
+        ob_end_clean();
+
+        $decoded = json_decode($content, true);
+        $this->assertSame(42, $decoded['id']);
+        $this->assertEquals('json', $decoded['format']);
+    }
+
+    public function testFloatCasting()
+    {
+        // scoreAction(float $id)
+        $route = new Route(
+            null,
+            null,
+            null,
+            ['id' => '3.14'],
+            TestAnnotatedController::class,
+            'scoreAction',
+            []
+        );
+        $request = new Request();
+        $result = Controller::execute($route, $request);
+        ob_start();
+        $result->send();
+        $content = ob_get_contents();
+        ob_end_clean();
+
+        $decoded = json_decode($content, true);
+        $this->assertSame(3.14, $decoded['id']);
+    }
+
+    public function testBoolCasting()
+    {
+        // activeAction(bool $id)
+        $route = new Route(
+            null,
+            null,
+            null,
+            ['id' => 'true'],
+            TestAnnotatedController::class,
+            'activeAction',
+            []
+        );
+        $request = new Request();
+        $result = Controller::execute($route, $request);
+        ob_start();
+        $result->send();
+        $content = ob_get_contents();
+        ob_end_clean();
+
+        $decoded = json_decode($content, true);
+        $this->assertSame(true, $decoded['id']);
+    }
+}

--- a/tests/Ngames/Framework/Tests/Router/Attribute/HttpMethodAttributeTest.php
+++ b/tests/Ngames/Framework/Tests/Router/Attribute/HttpMethodAttributeTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Ngames\Framework\Tests\Router\Attribute;
+
+use Ngames\Framework\Router\Attribute\Delete;
+use Ngames\Framework\Router\Attribute\Get;
+use Ngames\Framework\Router\Attribute\Post;
+use Ngames\Framework\Router\Attribute\Put;
+use PHPUnit\Framework\TestCase;
+
+class HttpMethodAttributeTest extends TestCase
+{
+    public function testGetStoresPath()
+    {
+        $attr = new Get('/:id');
+        $this->assertEquals('/:id', $attr->path);
+    }
+
+    public function testGetDefaultEmptyPath()
+    {
+        $attr = new Get();
+        $this->assertEquals('', $attr->path);
+    }
+
+    public function testPostStoresPath()
+    {
+        $attr = new Post('/create');
+        $this->assertEquals('/create', $attr->path);
+    }
+
+    public function testPutStoresPath()
+    {
+        $attr = new Put('/:id');
+        $this->assertEquals('/:id', $attr->path);
+    }
+
+    public function testDeleteStoresPath()
+    {
+        $attr = new Delete('/:id');
+        $this->assertEquals('/:id', $attr->path);
+    }
+
+    public function testGetIsMethodLevelAttribute()
+    {
+        $ref = new \ReflectionClass(Get::class);
+        $attrs = $ref->getAttributes(\Attribute::class);
+        $this->assertCount(1, $attrs);
+        $attr = $attrs[0]->newInstance();
+        $this->assertEquals(\Attribute::TARGET_METHOD, $attr->flags);
+    }
+
+    public function testPostIsMethodLevelAttribute()
+    {
+        $ref = new \ReflectionClass(Post::class);
+        $attrs = $ref->getAttributes(\Attribute::class);
+        $attr = $attrs[0]->newInstance();
+        $this->assertEquals(\Attribute::TARGET_METHOD, $attr->flags);
+    }
+
+    public function testPutIsMethodLevelAttribute()
+    {
+        $ref = new \ReflectionClass(Put::class);
+        $attrs = $ref->getAttributes(\Attribute::class);
+        $attr = $attrs[0]->newInstance();
+        $this->assertEquals(\Attribute::TARGET_METHOD, $attr->flags);
+    }
+
+    public function testDeleteIsMethodLevelAttribute()
+    {
+        $ref = new \ReflectionClass(Delete::class);
+        $attrs = $ref->getAttributes(\Attribute::class);
+        $attr = $attrs[0]->newInstance();
+        $this->assertEquals(\Attribute::TARGET_METHOD, $attr->flags);
+    }
+}

--- a/tests/Ngames/Framework/Tests/Router/Attribute/HttpMethodAttributeTest.php
+++ b/tests/Ngames/Framework/Tests/Router/Attribute/HttpMethodAttributeTest.php
@@ -4,6 +4,7 @@ namespace Ngames\Framework\Tests\Router\Attribute;
 
 use Ngames\Framework\Router\Attribute\Delete;
 use Ngames\Framework\Router\Attribute\Get;
+use Ngames\Framework\Router\Attribute\Patch;
 use Ngames\Framework\Router\Attribute\Post;
 use Ngames\Framework\Router\Attribute\Put;
 use PHPUnit\Framework\TestCase;
@@ -68,6 +69,26 @@ class HttpMethodAttributeTest extends TestCase
     public function testDeleteIsMethodLevelAttribute()
     {
         $ref = new \ReflectionClass(Delete::class);
+        $attrs = $ref->getAttributes(\Attribute::class);
+        $attr = $attrs[0]->newInstance();
+        $this->assertEquals(\Attribute::TARGET_METHOD, $attr->flags);
+    }
+
+    public function testPatchStoresPath()
+    {
+        $attr = new Patch('/:id');
+        $this->assertEquals('/:id', $attr->path);
+    }
+
+    public function testPatchDefaultEmptyPath()
+    {
+        $attr = new Patch();
+        $this->assertEquals('', $attr->path);
+    }
+
+    public function testPatchIsMethodLevelAttribute()
+    {
+        $ref = new \ReflectionClass(Patch::class);
         $attrs = $ref->getAttributes(\Attribute::class);
         $attr = $attrs[0]->newInstance();
         $this->assertEquals(\Attribute::TARGET_METHOD, $attr->flags);

--- a/tests/Ngames/Framework/Tests/Router/Attribute/MiddlewareTest.php
+++ b/tests/Ngames/Framework/Tests/Router/Attribute/MiddlewareTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Ngames\Framework\Tests\Router\Attribute;
+
+use Ngames\Framework\Router\Attribute\Middleware;
+use PHPUnit\Framework\TestCase;
+
+class MiddlewareTest extends TestCase
+{
+    public function testStoresClass()
+    {
+        $attr = new Middleware('App\\Middleware\\RequireAuth');
+        $this->assertEquals('App\\Middleware\\RequireAuth', $attr->class);
+    }
+
+    public function testIsRepeatableAndWorksOnClassAndMethod()
+    {
+        $ref = new \ReflectionClass(Middleware::class);
+        $attrs = $ref->getAttributes(\Attribute::class);
+        $this->assertCount(1, $attrs);
+        $attr = $attrs[0]->newInstance();
+        $expectedFlags = \Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE;
+        $this->assertEquals($expectedFlags, $attr->flags);
+    }
+}

--- a/tests/Ngames/Framework/Tests/Router/Attribute/RouteTest.php
+++ b/tests/Ngames/Framework/Tests/Router/Attribute/RouteTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Ngames\Framework\Tests\Router\Attribute;
+
+use Ngames\Framework\Router\Attribute\Route;
+use PHPUnit\Framework\TestCase;
+
+class RouteTest extends TestCase
+{
+    public function testStoresPath()
+    {
+        $route = new Route('/api/v1/users');
+        $this->assertEquals('/api/v1/users', $route->path);
+    }
+
+    public function testDefaultEmptyPath()
+    {
+        $route = new Route();
+        $this->assertEquals('', $route->path);
+    }
+
+    public function testIsClassLevelAttribute()
+    {
+        $ref = new \ReflectionClass(Route::class);
+        $attrs = $ref->getAttributes(\Attribute::class);
+        $this->assertCount(1, $attrs);
+        $attr = $attrs[0]->newInstance();
+        $this->assertEquals(\Attribute::TARGET_CLASS, $attr->flags);
+    }
+}

--- a/tests/Ngames/Framework/Tests/Router/MatcherTest.php
+++ b/tests/Ngames/Framework/Tests/Router/MatcherTest.php
@@ -28,66 +28,121 @@ use Ngames\Framework\Router\Matcher;
 
 class MatcherTest extends \PHPUnit\Framework\TestCase
 {
-    // Initialization error cases
-    public function testInvalidInitialization_missingModuleKeyAndValue()
+    // Annotated route tests (primary API)
+    public function testAnnotatedRoute_matchesPattern()
+    {
+        $matcher = new Matcher('/api/users/:id', 'GET', 'App\\UserController', 'show');
+        $result = $matcher->match('/api/users/42', 'GET');
+        $this->assertNotNull($result);
+        $this->assertTrue($result->isAnnotated());
+        $this->assertEquals('App\\UserController', $result->getControllerClass());
+        $this->assertEquals('show', $result->getActionMethod());
+        $this->assertEquals(['id' => '42'], $result->getParameters());
+    }
+
+    public function testAnnotatedRoute_noMatch()
+    {
+        $matcher = new Matcher('/api/users/:id', 'GET', 'App\\UserController', 'show');
+        $this->assertNull($matcher->match('/api/posts/42', 'GET'));
+    }
+
+    public function testAnnotatedRoute_methodConstraint()
+    {
+        $matcher = new Matcher('/api/users', 'POST', 'App\\UserController', 'create');
+        $this->assertNull($matcher->match('/api/users', 'GET'));
+        $this->assertNotNull($matcher->match('/api/users', 'POST'));
+    }
+
+    public function testAnnotatedRoute_methodIsCaseInsensitive()
+    {
+        $matcher = new Matcher('/test', 'get', 'App\\Ctrl', 'act');
+        $this->assertNotNull($matcher->match('/test', 'GET'));
+        $this->assertNotNull($matcher->match('/test', 'get'));
+    }
+
+    public function testAnnotatedRoute_middlewaresPassedToRoute()
+    {
+        $matcher = new Matcher('/test', 'GET', 'App\\Ctrl', 'act', ['App\\AuthMiddleware']);
+        $result = $matcher->match('/test', 'GET');
+        $this->assertEquals(['App\\AuthMiddleware'], $result->getMiddlewares());
+    }
+
+    public function testAnnotatedRoute_getName()
+    {
+        $matcher = new Matcher('/blog', 'GET', 'App\\BlogCtrl', 'index', [], 'blog');
+        $this->assertEquals('blog', $matcher->getName());
+    }
+
+    public function testAnnotatedRoute_getPattern()
+    {
+        $matcher = new Matcher('/blog', 'GET', 'App\\BlogCtrl', 'index');
+        $this->assertEquals('/blog', $matcher->getPattern());
+    }
+
+    public function testAnnotatedRoute_getMethod()
+    {
+        $matcher = new Matcher('/test', 'POST', 'App\\Ctrl', 'act');
+        $this->assertEquals('POST', $matcher->getMethod());
+    }
+
+    // Legacy convention-based route tests
+    public function testLegacy_invalidInitialization_missingModuleKeyAndValue()
     {
         $this->expectException('\Ngames\Framework\Router\InvalidMatcherException');
         $this->expectExceptionMessage('Missing module key or module value, or provided both');
-        new Matcher('/:controller/:action');
+        @Matcher::forConventionRoute('/:controller/:action');
     }
 
-    public function testInvalidInitialization_moduleKeyAndValue()
+    public function testLegacy_invalidInitialization_moduleKeyAndValue()
     {
         $this->expectException('\Ngames\Framework\Router\InvalidMatcherException');
         $this->expectExceptionMessage('Missing module key or module value, or provided both');
-        new Matcher('/:module', 'module');
+        @Matcher::forConventionRoute('/:module', 'module');
     }
 
-    public function testInvalidInitialization_missingControllerKeyAndValue()
+    public function testLegacy_invalidInitialization_missingControllerKeyAndValue()
     {
         $this->expectException('\Ngames\Framework\Router\InvalidMatcherException');
         $this->expectExceptionMessage('Missing controller key or controller value, or provided both');
-        new Matcher('/:module/:action');
+        @Matcher::forConventionRoute('/:module/:action');
     }
 
-    public function testInvalidInitialization_controllerKeyAndValue()
+    public function testLegacy_invalidInitialization_controllerKeyAndValue()
     {
         $this->expectException('\Ngames\Framework\Router\InvalidMatcherException');
         $this->expectExceptionMessage('Missing controller key or controller value, or provided both');
-        new Matcher('/:controller', 'module', 'controller');
+        @Matcher::forConventionRoute('/:controller', 'module', 'controller');
     }
 
-    public function testInvalidInitialization_missingActionKeyAndValue()
+    public function testLegacy_invalidInitialization_missingActionKeyAndValue()
     {
         $this->expectException('\Ngames\Framework\Router\InvalidMatcherException');
         $this->expectExceptionMessage('Missing action key or action value, or provided both');
-        new Matcher('/:module/:controller');
+        @Matcher::forConventionRoute('/:module/:controller');
     }
 
-    public function testInvalidInitialization_actionKeyAndValue()
+    public function testLegacy_invalidInitialization_actionKeyAndValue()
     {
         $this->expectException('\Ngames\Framework\Router\InvalidMatcherException');
         $this->expectExceptionMessage('Missing action key or action value, or provided both');
-        new Matcher('/:action', 'module', 'controller', 'action');
+        @Matcher::forConventionRoute('/:action', 'module', 'controller', 'action');
     }
 
-    // No match cases
-    public function testNoMatch()
+    public function testLegacy_noMatch()
     {
-        $matcher1 = new Matcher('/test', 'module1', 'controller1', 'action1');
+        $matcher1 = @Matcher::forConventionRoute('/test', 'module1', 'controller1', 'action1');
         $this->assertNull($matcher1->match('/test1'));
 
-        $matcher2 = new Matcher('/test/test', 'module2', 'controller2', 'action2');
+        $matcher2 = @Matcher::forConventionRoute('/test/test', 'module2', 'controller2', 'action2');
         $this->assertNull($matcher1->match('/test/test1'));
 
-        $matcher2 = new Matcher('/:module/:controller/:action');
+        $matcher2 = @Matcher::forConventionRoute('/:module/:controller/:action');
         $this->assertNull($matcher1->match('/module/controller/action/a'));
     }
 
-    // Match cases
-    public function testMatch_onlyDefault()
+    public function testLegacy_match_onlyDefault()
     {
-        $matcher1 = new Matcher('/test', 'module1', 'controller1', 'action1');
+        $matcher1 = @Matcher::forConventionRoute('/test', 'module1', 'controller1', 'action1');
         $result1 = $matcher1->match('/test');
         $this->assertNotNull($result1);
         $this->assertEquals('module1', $result1->getModuleName());
@@ -95,9 +150,9 @@ class MatcherTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('action1', $result1->getActionName());
     }
 
-    public function testMatch_matchModule()
+    public function testLegacy_match_matchModule()
     {
-        $matcher = new Matcher('/:module', null, 'controller', 'action');
+        $matcher = @Matcher::forConventionRoute('/:module', null, 'controller', 'action');
         $result = $matcher->match('/module-match');
         $this->assertNotNull($result);
         $this->assertEquals('module-match', $result->getModuleName());
@@ -105,9 +160,9 @@ class MatcherTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('action', $result->getActionName());
     }
 
-    public function testMatch_matchController()
+    public function testLegacy_match_matchController()
     {
-        $matcher = new Matcher('/:controller', 'module', null, 'action');
+        $matcher = @Matcher::forConventionRoute('/:controller', 'module', null, 'action');
         $result = $matcher->match('/controller-match');
         $this->assertNotNull($result);
         $this->assertEquals('module', $result->getModuleName());
@@ -115,9 +170,9 @@ class MatcherTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('action', $result->getActionName());
     }
 
-    public function testMatch_matchAction()
+    public function testLegacy_match_matchAction()
     {
-        $matcher = new Matcher('/:action', 'module', 'controller', null);
+        $matcher = @Matcher::forConventionRoute('/:action', 'module', 'controller', null);
         $result = $matcher->match('/action-match');
         $this->assertNotNull($result);
         $this->assertEquals('module', $result->getModuleName());
@@ -125,10 +180,9 @@ class MatcherTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('action-match', $result->getActionName());
     }
 
-    // Alias / custom parameter cases
-    public function testMatch_staticAlias()
+    public function testLegacy_match_staticAlias()
     {
-        $matcher = new Matcher('/blog', 'application', 'news', 'index');
+        $matcher = @Matcher::forConventionRoute('/blog', 'application', 'news', 'index');
         $result = $matcher->match('/blog');
         $this->assertNotNull($result);
         $this->assertEquals('application', $result->getModuleName());
@@ -137,9 +191,9 @@ class MatcherTest extends \PHPUnit\Framework\TestCase
         $this->assertEmpty($result->getParameters());
     }
 
-    public function testMatch_customParameter()
+    public function testLegacy_match_customParameter()
     {
-        $matcher = new Matcher('/article/:id', 'application', 'article', 'show');
+        $matcher = @Matcher::forConventionRoute('/article/:id', 'application', 'article', 'show');
         $result = $matcher->match('/article/42');
         $this->assertNotNull($result);
         $this->assertEquals('application', $result->getModuleName());
@@ -151,23 +205,23 @@ class MatcherTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('default', $result->getParameter('unknown', 'default'));
     }
 
-    public function testMatch_multipleCustomParameters()
+    public function testLegacy_match_multipleCustomParameters()
     {
-        $matcher = new Matcher('/article/:id/:slug', 'application', 'article', 'show');
+        $matcher = @Matcher::forConventionRoute('/article/:id/:slug', 'application', 'article', 'show');
         $result = $matcher->match('/article/42/my-title');
         $this->assertNotNull($result);
         $this->assertEquals(['id' => '42', 'slug' => 'my-title'], $result->getParameters());
     }
 
-    public function testMatch_customParameterNoMatch()
+    public function testLegacy_match_customParameterNoMatch()
     {
-        $matcher = new Matcher('/article/:id', 'application', 'article', 'show');
+        $matcher = @Matcher::forConventionRoute('/article/:id', 'application', 'article', 'show');
         $this->assertNull($matcher->match('/blog/42'));
     }
 
-    public function testMatch_defaultPatternStillWorks()
+    public function testLegacy_match_defaultPatternStillWorks()
     {
-        $matcher = new Matcher('/:module/:controller/:action');
+        $matcher = @Matcher::forConventionRoute('/:module/:controller/:action');
         $result = $matcher->match('/app/home/index');
         $this->assertNotNull($result);
         $this->assertEquals('app', $result->getModuleName());
@@ -176,58 +230,74 @@ class MatcherTest extends \PHPUnit\Framework\TestCase
         $this->assertEmpty($result->getParameters());
     }
 
-    public function testGetName()
+    public function testLegacy_getName()
     {
-        $matcher = new Matcher('/blog', 'app', 'news', 'index', 'blog');
+        $matcher = @Matcher::forConventionRoute('/blog', 'app', 'news', 'index', 'blog');
         $this->assertEquals('blog', $matcher->getName());
     }
 
-    public function testGetName_null()
+    public function testLegacy_getName_null()
     {
-        $matcher = new Matcher('/blog', 'app', 'news', 'index');
+        $matcher = @Matcher::forConventionRoute('/blog', 'app', 'news', 'index');
         $this->assertNull($matcher->getName());
     }
 
-    // HTTP method constraint tests
-    public function testMatchWithMethodGet_matchesGet()
+    public function testLegacy_matchWithMethodGet_matchesGet()
     {
-        $matcher = new Matcher('/test', 'mod', 'ctrl', 'act', null, 'GET');
+        $matcher = @Matcher::forConventionRoute('/test', 'mod', 'ctrl', 'act', null, 'GET');
         $result = $matcher->match('/test', 'GET');
         $this->assertNotNull($result);
     }
 
-    public function testMatchWithMethodGet_rejectsPost()
+    public function testLegacy_matchWithMethodGet_rejectsPost()
     {
-        $matcher = new Matcher('/test', 'mod', 'ctrl', 'act', null, 'GET');
+        $matcher = @Matcher::forConventionRoute('/test', 'mod', 'ctrl', 'act', null, 'GET');
         $result = $matcher->match('/test', 'POST');
         $this->assertNull($result);
     }
 
-    public function testMatchWithMethodNull_matchesAnyMethod()
+    public function testLegacy_matchWithMethodNull_matchesAnyMethod()
     {
-        $matcher = new Matcher('/test', 'mod', 'ctrl', 'act');
+        $matcher = @Matcher::forConventionRoute('/test', 'mod', 'ctrl', 'act');
         $this->assertNotNull($matcher->match('/test', 'GET'));
         $this->assertNotNull($matcher->match('/test', 'POST'));
         $this->assertNotNull($matcher->match('/test', 'DELETE'));
         $this->assertNotNull($matcher->match('/test'));
     }
 
-    public function testMatchWithMethodIsCaseInsensitive()
+    public function testLegacy_matchWithMethodIsCaseInsensitive()
     {
-        $matcher = new Matcher('/test', 'mod', 'ctrl', 'act', null, 'get');
+        $matcher = @Matcher::forConventionRoute('/test', 'mod', 'ctrl', 'act', null, 'get');
         $this->assertNotNull($matcher->match('/test', 'GET'));
         $this->assertNotNull($matcher->match('/test', 'get'));
     }
 
-    public function testGetMethod()
+    public function testLegacy_getMethod()
     {
-        $matcher = new Matcher('/test', 'mod', 'ctrl', 'act', null, 'POST');
+        $matcher = @Matcher::forConventionRoute('/test', 'mod', 'ctrl', 'act', null, 'POST');
         $this->assertEquals('POST', $matcher->getMethod());
     }
 
-    public function testGetMethod_null()
+    public function testLegacy_getMethod_null()
     {
-        $matcher = new Matcher('/test', 'mod', 'ctrl', 'act');
+        $matcher = @Matcher::forConventionRoute('/test', 'mod', 'ctrl', 'act');
         $this->assertNull($matcher->getMethod());
+    }
+
+    // Deprecation notice test
+    public function testLegacy_triggersDeprecationNotice()
+    {
+        $deprecationTriggered = false;
+        set_error_handler(function ($errno) use (&$deprecationTriggered) {
+            if ($errno === E_USER_DEPRECATED) {
+                $deprecationTriggered = true;
+            }
+            return true;
+        });
+
+        Matcher::forConventionRoute('/test', 'mod', 'ctrl', 'act');
+
+        restore_error_handler();
+        $this->assertTrue($deprecationTriggered);
     }
 }

--- a/tests/Ngames/Framework/Tests/Router/MatcherTest.php
+++ b/tests/Ngames/Framework/Tests/Router/MatcherTest.php
@@ -187,4 +187,47 @@ class MatcherTest extends \PHPUnit\Framework\TestCase
         $matcher = new Matcher('/blog', 'app', 'news', 'index');
         $this->assertNull($matcher->getName());
     }
+
+    // HTTP method constraint tests
+    public function testMatchWithMethodGet_matchesGet()
+    {
+        $matcher = new Matcher('/test', 'mod', 'ctrl', 'act', null, 'GET');
+        $result = $matcher->match('/test', 'GET');
+        $this->assertNotNull($result);
+    }
+
+    public function testMatchWithMethodGet_rejectsPost()
+    {
+        $matcher = new Matcher('/test', 'mod', 'ctrl', 'act', null, 'GET');
+        $result = $matcher->match('/test', 'POST');
+        $this->assertNull($result);
+    }
+
+    public function testMatchWithMethodNull_matchesAnyMethod()
+    {
+        $matcher = new Matcher('/test', 'mod', 'ctrl', 'act');
+        $this->assertNotNull($matcher->match('/test', 'GET'));
+        $this->assertNotNull($matcher->match('/test', 'POST'));
+        $this->assertNotNull($matcher->match('/test', 'DELETE'));
+        $this->assertNotNull($matcher->match('/test'));
+    }
+
+    public function testMatchWithMethodIsCaseInsensitive()
+    {
+        $matcher = new Matcher('/test', 'mod', 'ctrl', 'act', null, 'get');
+        $this->assertNotNull($matcher->match('/test', 'GET'));
+        $this->assertNotNull($matcher->match('/test', 'get'));
+    }
+
+    public function testGetMethod()
+    {
+        $matcher = new Matcher('/test', 'mod', 'ctrl', 'act', null, 'POST');
+        $this->assertEquals('POST', $matcher->getMethod());
+    }
+
+    public function testGetMethod_null()
+    {
+        $matcher = new Matcher('/test', 'mod', 'ctrl', 'act');
+        $this->assertNull($matcher->getMethod());
+    }
 }

--- a/tests/Ngames/Framework/Tests/Router/MiddlewareTest.php
+++ b/tests/Ngames/Framework/Tests/Router/MiddlewareTest.php
@@ -32,13 +32,10 @@ class MiddlewareTest extends TestCase
 
     public function testClassLevelMiddlewareRunsForAllMethods()
     {
-        $route = new Route(
-            null,
-            null,
-            null,
-            [],
+        $route = Route::create(
             TestAnnotatedController::class,
             'listAction',
+            [],
             [TestClassMiddleware::class]
         );
         $request = new Request();
@@ -48,13 +45,10 @@ class MiddlewareTest extends TestCase
 
     public function testMethodLevelMiddlewareStacksOnTopOfClassLevel()
     {
-        $route = new Route(
-            null,
-            null,
-            null,
-            ['id' => '42'],
+        $route = Route::create(
             TestAnnotatedController::class,
             'deleteAction',
+            ['id' => '42'],
             [TestClassMiddleware::class, TestMethodMiddleware::class]
         );
         $request = new Request();
@@ -65,13 +59,10 @@ class MiddlewareTest extends TestCase
 
     public function testMiddlewareCanShortCircuit()
     {
-        $route = new Route(
-            null,
-            null,
-            null,
-            [],
+        $route = Route::create(
             TestAnnotatedController::class,
             'listAction',
+            [],
             [TestShortCircuitMiddleware::class]
         );
         $request = new Request();
@@ -89,20 +80,15 @@ class MiddlewareTest extends TestCase
 
     public function testMiddlewareExecutionOrder()
     {
-        // Class middleware runs first (outermost), then method middleware
-        $route = new Route(
-            null,
-            null,
-            null,
-            ['id' => '1'],
+        $route = Route::create(
             TestAnnotatedController::class,
             'deleteAction',
+            ['id' => '1'],
             [TestClassMiddleware::class, TestMethodMiddleware::class]
         );
         $request = new Request();
         $result = Controller::execute($route, $request);
 
-        // Both middlewares should have run and added their headers
         $headers = $result->getHeaders();
         $this->assertArrayHasKey('X-Class-Middleware', $headers);
         $this->assertArrayHasKey('X-Method-Middleware', $headers);
@@ -110,12 +96,10 @@ class MiddlewareTest extends TestCase
 
     public function testNonAnnotatedRoutesSkipMiddleware()
     {
-        // Use the existing convention route - no middleware metadata
-        $route = new Route('application', 'dummy', 'index');
+        $route = Route::createLegacy('application', 'dummy', 'index');
         $request = new Request();
         $result = Controller::execute($route, $request);
 
-        // Should work as before, no middleware headers
         ob_start();
         $result->send();
         $content = ob_get_contents();

--- a/tests/Ngames/Framework/Tests/Router/MiddlewareTest.php
+++ b/tests/Ngames/Framework/Tests/Router/MiddlewareTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Ngames\Framework\Tests\Router;
+
+use Ngames\Framework\Application;
+use Ngames\Framework\Controller;
+use Ngames\Framework\Request;
+use Ngames\Framework\Router\Route;
+use Ngames\Framework\Tests\Fixtures\TestAnnotatedController;
+use Ngames\Framework\Tests\Fixtures\TestClassMiddleware;
+use Ngames\Framework\Tests\Fixtures\TestMethodMiddleware;
+use Ngames\Framework\Tests\Fixtures\TestShortCircuitMiddleware;
+use PHPUnit\Framework\TestCase;
+
+class MiddlewareTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $reflection = new \ReflectionClass(Application::class);
+        $instance = $reflection->getProperty('instance');
+        $instance->setValue(null, null);
+
+        Application::initialize(ROOT_DIR . '/tests/data/Application/config.ini');
+    }
+
+    protected function tearDown(): void
+    {
+        $reflection = new \ReflectionClass(Application::class);
+        $instance = $reflection->getProperty('instance');
+        $instance->setValue(null, null);
+    }
+
+    public function testClassLevelMiddlewareRunsForAllMethods()
+    {
+        $route = new Route(
+            null,
+            null,
+            null,
+            [],
+            TestAnnotatedController::class,
+            'listAction',
+            [TestClassMiddleware::class]
+        );
+        $request = new Request();
+        $result = Controller::execute($route, $request);
+        $this->assertEquals('applied', $result->getHeaders()['X-Class-Middleware']);
+    }
+
+    public function testMethodLevelMiddlewareStacksOnTopOfClassLevel()
+    {
+        $route = new Route(
+            null,
+            null,
+            null,
+            ['id' => '42'],
+            TestAnnotatedController::class,
+            'deleteAction',
+            [TestClassMiddleware::class, TestMethodMiddleware::class]
+        );
+        $request = new Request();
+        $result = Controller::execute($route, $request);
+        $this->assertEquals('applied', $result->getHeaders()['X-Class-Middleware']);
+        $this->assertEquals('applied', $result->getHeaders()['X-Method-Middleware']);
+    }
+
+    public function testMiddlewareCanShortCircuit()
+    {
+        $route = new Route(
+            null,
+            null,
+            null,
+            [],
+            TestAnnotatedController::class,
+            'listAction',
+            [TestShortCircuitMiddleware::class]
+        );
+        $request = new Request();
+        ob_start();
+        $result = Controller::execute($route, $request);
+        ob_end_clean();
+        $this->assertEquals(401, $result->getHeaders()['Content-Type'] ? 401 : 200);
+        // Short-circuit returns unauthorized
+        ob_start();
+        $result->send();
+        $content = ob_get_contents();
+        ob_end_clean();
+        $this->assertEquals('Blocked by middleware', $content);
+    }
+
+    public function testMiddlewareExecutionOrder()
+    {
+        // Class middleware runs first (outermost), then method middleware
+        $route = new Route(
+            null,
+            null,
+            null,
+            ['id' => '1'],
+            TestAnnotatedController::class,
+            'deleteAction',
+            [TestClassMiddleware::class, TestMethodMiddleware::class]
+        );
+        $request = new Request();
+        $result = Controller::execute($route, $request);
+
+        // Both middlewares should have run and added their headers
+        $headers = $result->getHeaders();
+        $this->assertArrayHasKey('X-Class-Middleware', $headers);
+        $this->assertArrayHasKey('X-Method-Middleware', $headers);
+    }
+
+    public function testNonAnnotatedRoutesSkipMiddleware()
+    {
+        // Use the existing convention route - no middleware metadata
+        $route = new Route('application', 'dummy', 'index');
+        $request = new Request();
+        $result = Controller::execute($route, $request);
+
+        // Should work as before, no middleware headers
+        ob_start();
+        $result->send();
+        $content = ob_get_contents();
+        ob_end_clean();
+        $this->assertEquals('index', $content);
+    }
+}

--- a/tests/Ngames/Framework/Tests/Router/RouteCollectorTest.php
+++ b/tests/Ngames/Framework/Tests/Router/RouteCollectorTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Ngames\Framework\Tests\Router;
+
+use Ngames\Framework\Router\Router;
+use Ngames\Framework\Router\RouteCollector;
+use Ngames\Framework\Tests\Fixtures\TestAnnotatedController;
+use PHPUnit\Framework\TestCase;
+
+class RouteCollectorTest extends TestCase
+{
+    private string $fixturesDir;
+
+    protected function setUp(): void
+    {
+        $this->fixturesDir = __DIR__ . '/../Fixtures';
+    }
+
+    public function testScansAnnotatedControllers()
+    {
+        $router = new Router();
+        $collector = new RouteCollector();
+        $collector->collect([$this->fixturesDir], $router);
+
+        // Should find the GET /api/v1/alliances route
+        $route = $router->getRoute('/api/v1/alliances', 'GET');
+        $this->assertNotNull($route);
+        $this->assertTrue($route->isAnnotated());
+        $this->assertEquals(TestAnnotatedController::class, $route->getControllerClass());
+    }
+
+    public function testConcatenatesClassAndMethodPaths()
+    {
+        $router = new Router();
+        $collector = new RouteCollector();
+        $collector->collect([$this->fixturesDir], $router);
+
+        $route = $router->getRoute('/api/v1/alliances/42', 'GET');
+        $this->assertNotNull($route);
+        $this->assertEquals('showAction', $route->getActionMethod());
+        $this->assertEquals(['id' => '42'], $route->getParameters());
+    }
+
+    public function testRegistersMatchersWithHttpMethodConstraints()
+    {
+        $router = new Router();
+        $collector = new RouteCollector();
+        $collector->collect([$this->fixturesDir], $router);
+
+        // GET and DELETE both match /api/v1/alliances/:id but with different methods
+        $getRoute = $router->getRoute('/api/v1/alliances/42', 'GET');
+        $this->assertNotNull($getRoute);
+        $this->assertEquals('showAction', $getRoute->getActionMethod());
+
+        $deleteRoute = $router->getRoute('/api/v1/alliances/42', 'DELETE');
+        $this->assertNotNull($deleteRoute);
+        $this->assertEquals('deleteAction', $deleteRoute->getActionMethod());
+    }
+
+    public function testCapturesPathParameters()
+    {
+        $router = new Router();
+        $collector = new RouteCollector();
+        $collector->collect([$this->fixturesDir], $router);
+
+        $route = $router->getRoute('/api/v1/alliances/42/members/7/accept', 'POST');
+        $this->assertNotNull($route);
+        $this->assertEquals('acceptAction', $route->getActionMethod());
+        $this->assertEquals(['id' => '42', 'userId' => '7'], $route->getParameters());
+    }
+
+    public function testSkipsClassesWithoutRouteAttribute()
+    {
+        $router = new Router();
+        $collector = new RouteCollector();
+        $collector->collect([$this->fixturesDir], $router);
+
+        // TestNoAttributeController has no #[Route], so it shouldn't register anything
+        // We can verify by checking that only annotated routes exist
+        $this->assertNull($router->getRoute('/no-attribute-path', 'GET'));
+    }
+
+    public function testCollectsMiddlewares()
+    {
+        $router = new Router();
+        $collector = new RouteCollector();
+        $collector->collect([$this->fixturesDir], $router);
+
+        // The delete route has both class-level and method-level middleware
+        $route = $router->getRoute('/api/v1/alliances/42', 'DELETE');
+        $this->assertNotNull($route);
+        $middlewares = $route->getMiddlewares();
+        $this->assertCount(2, $middlewares);
+    }
+
+    public function testClearCache()
+    {
+        $collector = new RouteCollector();
+        // Should not throw even if APCu is not available
+        $collector->clearCache();
+        $this->assertTrue(true);
+    }
+
+    public function testNonExistentDirectory()
+    {
+        $router = new Router();
+        $collector = new RouteCollector();
+        $collector->collect(['/non/existent/directory'], $router);
+
+        $this->assertNull($router->getRoute('/anything', 'GET'));
+    }
+}

--- a/tests/Ngames/Framework/Tests/Router/RouteCollectorTest.php
+++ b/tests/Ngames/Framework/Tests/Router/RouteCollectorTest.php
@@ -109,4 +109,16 @@ class RouteCollectorTest extends TestCase
 
         $this->assertNull($router->getRoute('/anything', 'GET'));
     }
+
+    public function testPatchMethodRoutes()
+    {
+        $router = new Router();
+        $collector = new RouteCollector();
+        $collector->collect([$this->fixturesDir], $router);
+
+        $route = $router->getRoute('/api/v1/alliances/42', 'PATCH');
+        $this->assertNotNull($route);
+        $this->assertEquals('updateAction', $route->getActionMethod());
+        $this->assertEquals(['id' => '42'], $route->getParameters());
+    }
 }

--- a/tests/Ngames/Framework/Tests/Router/RouterTest.php
+++ b/tests/Ngames/Framework/Tests/Router/RouterTest.php
@@ -32,8 +32,6 @@ class RouterTest extends \PHPUnit\Framework\TestCase
     public function testGetRoute_noRouteDefined()
     {
         $router = new Router();
-
-        // No route defined
         $route = $router->getRoute('/');
         $this->assertNull($route);
     }
@@ -41,7 +39,7 @@ class RouterTest extends \PHPUnit\Framework\TestCase
     public function testGetRoute_match()
     {
         $router = new Router();
-        $router->addMatcher(new Matcher('/', 'default-module', 'default-controller', 'default-action'));
+        $router->addMatcher(@Matcher::forConventionRoute('/', 'default-module', 'default-controller', 'default-action'));
         $route = $router->getRoute('/');
         $this->assertEquals('default-module', $route->getModuleName());
         $this->assertEquals('default-controller', $route->getControllerName());
@@ -51,7 +49,7 @@ class RouterTest extends \PHPUnit\Framework\TestCase
     public function testGetRoute_noMatch()
     {
         $router = new Router();
-        $router->addMatcher(new Matcher('/test', 'default-module', 'default-controller', 'default-action'));
+        $router->addMatcher(@Matcher::forConventionRoute('/test', 'default-module', 'default-controller', 'default-action'));
         $route = $router->getRoute('/test1');
         $this->assertNull($route);
     }
@@ -59,8 +57,8 @@ class RouterTest extends \PHPUnit\Framework\TestCase
     public function testGetRoute_routeOrder()
     {
         $router = new Router();
-        $router->addMatcher(new Matcher('/test', 'test1-module', 'test1-controller', 'test1-action'));
-        $router->addMatcher(new Matcher('/test', 'test2-module', 'test2-controller', 'test2-action'));
+        $router->addMatcher(@Matcher::forConventionRoute('/test', 'test1-module', 'test1-controller', 'test1-action'));
+        $router->addMatcher(@Matcher::forConventionRoute('/test', 'test2-module', 'test2-controller', 'test2-action'));
         $route = $router->getRoute('/test');
         $this->assertEquals('test1-module', $route->getModuleName());
         $this->assertEquals('test1-controller', $route->getControllerName());
@@ -70,14 +68,14 @@ class RouterTest extends \PHPUnit\Framework\TestCase
     public function testUrl_namedRoute()
     {
         $router = new Router();
-        $router->addMatcher(new Matcher('/article/:id', 'app', 'article', 'show', 'article'));
+        $router->addMatcher(@Matcher::forConventionRoute('/article/:id', 'app', 'article', 'show', 'article'));
         $this->assertEquals('/article/42', $router->url('article', ['id' => '42']));
     }
 
     public function testUrl_namedRouteNoParams()
     {
         $router = new Router();
-        $router->addMatcher(new Matcher('/blog', 'app', 'news', 'index', 'blog'));
+        $router->addMatcher(@Matcher::forConventionRoute('/blog', 'app', 'news', 'index', 'blog'));
         $this->assertEquals('/blog', $router->url('blog'));
     }
 
@@ -91,8 +89,8 @@ class RouterTest extends \PHPUnit\Framework\TestCase
     public function testGetRoute_aliasBeforeDefault()
     {
         $router = new Router();
-        $router->addMatcher(new Matcher('/blog', 'app', 'news', 'index', 'blog'));
-        $router->addMatcher(new Matcher('/:module/:controller/:action'));
+        $router->addMatcher(@Matcher::forConventionRoute('/blog', 'app', 'news', 'index', 'blog'));
+        $router->addMatcher(@Matcher::forConventionRoute('/:module/:controller/:action'));
         $route = $router->getRoute('/blog');
         $this->assertEquals('app', $route->getModuleName());
         $this->assertEquals('news', $route->getControllerName());
@@ -103,8 +101,8 @@ class RouterTest extends \PHPUnit\Framework\TestCase
     public function testGetRoute_withMethodPicksCorrectMatcher()
     {
         $router = new Router();
-        $router->addMatcher(new Matcher('/test', 'mod', 'ctrl', 'get-action', null, 'GET'));
-        $router->addMatcher(new Matcher('/test', 'mod', 'ctrl', 'delete-action', null, 'DELETE'));
+        $router->addMatcher(@Matcher::forConventionRoute('/test', 'mod', 'ctrl', 'get-action', null, 'GET'));
+        $router->addMatcher(@Matcher::forConventionRoute('/test', 'mod', 'ctrl', 'delete-action', null, 'DELETE'));
 
         $getRoute = $router->getRoute('/test', 'GET');
         $this->assertNotNull($getRoute);
@@ -118,7 +116,7 @@ class RouterTest extends \PHPUnit\Framework\TestCase
     public function testGetRoute_withoutMethodStillWorks()
     {
         $router = new Router();
-        $router->addMatcher(new Matcher('/test', 'mod', 'ctrl', 'act'));
+        $router->addMatcher(@Matcher::forConventionRoute('/test', 'mod', 'ctrl', 'act'));
         $route = $router->getRoute('/test');
         $this->assertNotNull($route);
         $this->assertEquals('act', $route->getActionName());
@@ -127,8 +125,26 @@ class RouterTest extends \PHPUnit\Framework\TestCase
     public function testGetRoute_methodConstraintNoMatch()
     {
         $router = new Router();
-        $router->addMatcher(new Matcher('/test', 'mod', 'ctrl', 'act', null, 'GET'));
+        $router->addMatcher(@Matcher::forConventionRoute('/test', 'mod', 'ctrl', 'act', null, 'GET'));
         $route = $router->getRoute('/test', 'POST');
         $this->assertNull($route);
+    }
+
+    // Annotated route tests
+    public function testGetRoute_annotatedRoute()
+    {
+        $router = new Router();
+        $router->addMatcher(new Matcher('/api/users/:id', 'GET', 'App\\UserCtrl', 'show'));
+        $route = $router->getRoute('/api/users/42', 'GET');
+        $this->assertNotNull($route);
+        $this->assertTrue($route->isAnnotated());
+        $this->assertEquals('App\\UserCtrl', $route->getControllerClass());
+    }
+
+    public function testUrl_annotatedNamedRoute()
+    {
+        $router = new Router();
+        $router->addMatcher(new Matcher('/api/users/:id', 'GET', 'App\\UserCtrl', 'show', [], 'user.show'));
+        $this->assertEquals('/api/users/42', $router->url('user.show', ['id' => '42']));
     }
 }

--- a/tests/Ngames/Framework/Tests/Router/RouterTest.php
+++ b/tests/Ngames/Framework/Tests/Router/RouterTest.php
@@ -98,4 +98,37 @@ class RouterTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('news', $route->getControllerName());
         $this->assertEquals('index', $route->getActionName());
     }
+
+    // HTTP method routing tests
+    public function testGetRoute_withMethodPicksCorrectMatcher()
+    {
+        $router = new Router();
+        $router->addMatcher(new Matcher('/test', 'mod', 'ctrl', 'get-action', null, 'GET'));
+        $router->addMatcher(new Matcher('/test', 'mod', 'ctrl', 'delete-action', null, 'DELETE'));
+
+        $getRoute = $router->getRoute('/test', 'GET');
+        $this->assertNotNull($getRoute);
+        $this->assertEquals('get-action', $getRoute->getActionName());
+
+        $deleteRoute = $router->getRoute('/test', 'DELETE');
+        $this->assertNotNull($deleteRoute);
+        $this->assertEquals('delete-action', $deleteRoute->getActionName());
+    }
+
+    public function testGetRoute_withoutMethodStillWorks()
+    {
+        $router = new Router();
+        $router->addMatcher(new Matcher('/test', 'mod', 'ctrl', 'act'));
+        $route = $router->getRoute('/test');
+        $this->assertNotNull($route);
+        $this->assertEquals('act', $route->getActionName());
+    }
+
+    public function testGetRoute_methodConstraintNoMatch()
+    {
+        $router = new Router();
+        $router->addMatcher(new Matcher('/test', 'mod', 'ctrl', 'act', null, 'GET'));
+        $route = $router->getRoute('/test', 'POST');
+        $this->assertNull($route);
+    }
 }

--- a/tests/Ngames/Framework/Tests/ViewTest.php
+++ b/tests/Ngames/Framework/Tests/ViewTest.php
@@ -82,7 +82,7 @@ class ViewTest extends \PHPUnit\Framework\TestCase
 
     public function testSetScriptFromRoute()
     {
-        $route = new Route('module', 'controller', 'action');
+        $route = Route::createLegacy('module', 'controller', 'action');
         $view = new View();
         $view->setScriptFromRoute($route);
         $this->assertEquals('module/controller/action', $view->getScript());


### PR DESCRIPTION
## Summary
This PR introduces a complete attribute-based routing system to the framework, allowing developers to define routes using PHP 8 attributes instead of convention-based routing. It includes automatic route collection, HTTP method constraints, parameter injection with type casting, and middleware support.

## Key Changes

### New Routing Attributes
- Added `#[Route]` class-level attribute for defining base paths
- Added HTTP method attributes: `#[Get]`, `#[Post]`, `#[Put]`, `#[Delete]` for method-level route definitions
- Added `#[Middleware]` repeatable attribute for class and method-level middleware registration

### Route Collection & Discovery
- Implemented `RouteCollector` class that:
  - Scans directories for annotated controller classes
  - Extracts fully qualified class names from PHP files using regex
  - Processes route and middleware attributes via reflection
  - Caches routes using APCu when available with fallback to runtime scanning
  - Logs warnings when APCu is unavailable

### Enhanced Router & Matcher
- Extended `Matcher` to support HTTP method constraints (`GET`, `POST`, `PUT`, `DELETE`)
- Updated `Router::getRoute()` to accept optional HTTP method parameter
- Modified `Route` class to store annotated route metadata:
  - `controllerClass` and `actionMethod` for direct class/method dispatch
  - `middlewares` array for middleware chain execution
  - `isAnnotated()` method to distinguish annotated from convention routes

### Parameter Injection & Type Casting
- Implemented `Controller::executeAnnotated()` for annotated route dispatch
- Added `Controller::resolveParameters()` for automatic parameter resolution:
  - Extracts method parameters via reflection
  - Casts route parameters to declared types (int, float, bool, string)
  - Supports optional parameters with default values
  - Returns 400 Bad Request for missing required parameters

### Middleware Pipeline
- Implemented middleware chain execution in `executeAnnotated()`
- Supports both class-level (applies to all methods) and method-level middleware
- Allows middleware to short-circuit the request (return early without calling action)
- Middleware receives `Request` and `next` callable for pipeline continuation

### Application Integration
- Added `Application::registerAnnotatedControllers()` method for convenient route registration
- Updated `composer.json` to require PHP 8.4+ and suggest APCu extension

## Notable Implementation Details

- Route patterns support path parameters using `:paramName` syntax (e.g., `/api/v1/alliances/:id`)
- Class and method paths are concatenated with proper slash handling
- Middleware execution order: class-level middlewares run first (outermost), then method-level
- APCu caching uses a configurable prefix (`ngames_routes_compiled` by default)
- Annotated routes coexist with convention-based routes in the same router
- Type casting handles edge cases (e.g., `'true'` string → `true` boolean)

https://claude.ai/code/session_016gvSF2b4g94ttTrumpnc2u