### PR TITLE
Remove version field from composer.json and update lock file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
             "Ngames\\Framework\\" : "lib/Ngames/Framework/"
         }
     },
-    "version": "0.6.0",
     "require": {
         "php": ">= 8.5"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1791c5df07b7da9fb1ef0ac876da53f8",
+    "content-hash": "148b4b845aa12b3c52a1d09162563307",
     "packages": [],
     "packages-dev": [
         {
@@ -4292,7 +4292,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">= 8.4"
+        "php": ">= 8.5"
     },
     "platform-dev": {},
     "plugin-api-version": "2.6.0"


### PR DESCRIPTION
The version field is not recommended for Packagist-published packages, and the lock file needed regeneration after the PHP requirement change.

https://claude.ai/code/session_016gvSF2b4g94ttTrumpnc2u